### PR TITLE
Multiple Displays Sharing Reset

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -180,18 +180,24 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr) {
 	Wire.begin(); // Is this the right place for this?
   }
 
-  // Setup reset pin direction (used by both SPI and I2C)  
-  pinMode(rst, OUTPUT);
-  digitalWrite(rst, HIGH);
-  // VDD (3.3V) goes high at start, lets just chill for a ms
-  delay(1);
-  // bring reset low
-  digitalWrite(rst, LOW);
-  // wait 10ms
-  delay(10);
-  // bring out of reset
-  digitalWrite(rst, HIGH);
-  // turn on VCC (9V?)
+  // Only reset the displays once
+  static int8_t hasReset = 0;
+  if (hasReset == 0)
+  {
+    hasReset = 1;
+    // Setup reset pin direction (used by both SPI and I2C)
+    pinMode(rst, OUTPUT);
+    digitalWrite(rst, HIGH);
+    // VDD (3.3V) goes high at start, lets just chill for a ms
+    delay(1);
+    // bring reset low
+    digitalWrite(rst, LOW);
+    // wait 10ms
+    delay(10);
+    // bring out of reset
+    digitalWrite(rst, HIGH);
+    // turn on VCC (9V?)
+  }
 
    #if defined SSD1306_128_32
     // Init sequence for 128x32 OLED module


### PR DESCRIPTION
This requires that all displays share the same reset pin.

I have the same problem as described in the following post:
http://adafruit.com/forums/viewtopic.php?f=47&t=32745

The fix that I found to work was to wrap the reset in an if that only allows it to run once using a static flag. Now I can share my rst pin between all my displays. The side effect is that you only can reset once. There are lots of ways to fix this, but since it has been working for me, I haven't done anything about it.  For instance using a 32 bit int to store which pins have been reset.
