### PR TITLE
Fix prototype

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -149,7 +149,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void);
 
-  void dim(uint8_t contrast);
+  void dim(boolean dim);
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 


### PR DESCRIPTION
Prototype would throw errors due to difference in definition, changed to match. Only showed up when I changed to the Sublime/Stino environment. 