### PR TITLE
create segmented renderer to reduce SRAM requirements

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -4,14 +4,14 @@ This is a library for our Monochrome OLEDs based on SSD1306 drivers
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/category/63_98
 
-These displays use SPI to communicate, 4 or 5 pins are required to  
+These displays use SPI to communicate, 4 or 5 pins are required to
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen below must be included in any redistribution
 *********************************************************************/
@@ -29,7 +29,11 @@ All text above, and the splash screen below must be included in any redistributi
 
 // the memory buffer for the LCD
 
-static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = { 
+#if SSD1306_SEGMENTS > 1
+static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8 /  SSD1306_SEGMENTS];
+#else
+
+static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -99,6 +103,7 @@ static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
 #endif
 #endif
 };
+#endif
 
 
 
@@ -121,16 +126,19 @@ void Adafruit_SSD1306::drawPixel(int16_t x, int16_t y, uint16_t color) {
     swap(x, y);
     y = HEIGHT - y - 1;
     break;
-  }  
+  }
 
-  // x is which column
-    switch (color) 
+  if (inSegment(y)) {
+    y = ySegmentOffset(y);
+    // x is which column
+    switch (color)
     {
       case WHITE:   buffer[x+ (y/8)*SSD1306_LCDWIDTH] |=  (1 << (y&7)); break;
-      case BLACK:   buffer[x+ (y/8)*SSD1306_LCDWIDTH] &= ~(1 << (y&7)); break; 
-      case INVERSE: buffer[x+ (y/8)*SSD1306_LCDWIDTH] ^=  (1 << (y&7)); break; 
+      case BLACK:   buffer[x+ (y/8)*SSD1306_LCDWIDTH] &= ~(1 << (y&7)); break;
+      case INVERSE: buffer[x+ (y/8)*SSD1306_LCDWIDTH] ^=  (1 << (y&7)); break;
     }
-    
+  }
+
 }
 
 Adafruit_SSD1306::Adafruit_SSD1306(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST, int8_t CS) : Adafruit_GFX(SSD1306_LCDWIDTH, SSD1306_LCDHEIGHT) {
@@ -140,9 +148,10 @@ Adafruit_SSD1306::Adafruit_SSD1306(int8_t SID, int8_t SCLK, int8_t DC, int8_t RS
   sclk = SCLK;
   sid = SID;
   hwSPI = false;
+  segment = 0;
 }
 
-// constructor for hardware SPI - we indicate DataCommand, ChipSelect, Reset 
+// constructor for hardware SPI - we indicate DataCommand, ChipSelect, Reset
 Adafruit_SSD1306::Adafruit_SSD1306(int8_t DC, int8_t RST, int8_t CS) : Adafruit_GFX(SSD1306_LCDWIDTH, SSD1306_LCDHEIGHT) {
   dc = DC;
   rst = RST;
@@ -156,7 +165,7 @@ Adafruit_GFX(SSD1306_LCDWIDTH, SSD1306_LCDHEIGHT) {
   sclk = dc = cs = sid = -1;
   rst = reset;
 }
-  
+
 
 void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
   _vccstate = vccstate;
@@ -200,7 +209,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
   }
 
   if (reset) {
-    // Setup reset pin direction (used by both SPI and I2C)  
+    // Setup reset pin direction (used by both SPI and I2C)
     pinMode(rst, OUTPUT);
     digitalWrite(rst, HIGH);
     // VDD (3.3V) goes high at start, lets just chill for a ms
@@ -225,9 +234,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(0x0);                                   // no offset
     ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
     ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x10); }
-    else 
+    else
       { ssd1306_command(0x14); }
     ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
     ssd1306_command(0x00);                                  // 0x0 act like ks0108
@@ -238,9 +247,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
     ssd1306_command(0x8F);
     ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x22); }
-    else 
+    else
       { ssd1306_command(0xF1); }
     ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
     ssd1306_command(0x40);
@@ -259,9 +268,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(0x0);                                   // no offset
     ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
     ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x10); }
-    else 
+    else
       { ssd1306_command(0x14); }
     ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
     ssd1306_command(0x00);                                  // 0x0 act like ks0108
@@ -270,14 +279,14 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
     ssd1306_command(0x12);
     ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x9F); }
-    else 
+    else
       { ssd1306_command(0xCF); }
     ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x22); }
-    else 
+    else
       { ssd1306_command(0xF1); }
     ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
     ssd1306_command(0x40);
@@ -296,9 +305,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(0x00);                                   // no offset
     ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
     ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x10); }
-    else 
+    else
       { ssd1306_command(0x14); }
     ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
     ssd1306_command(0x00);                                  // 0x0 act like ks0108
@@ -307,14 +316,14 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
     ssd1306_command(0x2);	//ada x12
     ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x10); }
-    else 
+    else
       { ssd1306_command(0xAF); }
     ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC) 
+    if (vccstate == SSD1306_EXTERNALVCC)
       { ssd1306_command(0x22); }
-    else 
+    else
       { ssd1306_command(0xF1); }
     ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
     ssd1306_command(0x40);
@@ -334,7 +343,7 @@ void Adafruit_SSD1306::invertDisplay(uint8_t i) {
   }
 }
 
-void Adafruit_SSD1306::ssd1306_command(uint8_t c) { 
+void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
   if (sid != -1)
   {
     // SPI
@@ -362,7 +371,7 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
 // startscrollright
 // Activate a right handed scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F) 
+// display.scrollright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_RIGHT_HORIZONTAL_SCROLL);
   ssd1306_command(0X00);
@@ -377,7 +386,7 @@ void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop){
 // startscrollleft
 // Activate a right handed scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F) 
+// display.scrollright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_LEFT_HORIZONTAL_SCROLL);
   ssd1306_command(0X00);
@@ -392,9 +401,9 @@ void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop){
 // startscrolldiagright
 // Activate a diagonal scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F) 
+// display.scrollright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop){
-  ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);  
+  ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);
   ssd1306_command(0X00);
   ssd1306_command(SSD1306_LCDHEIGHT);
   ssd1306_command(SSD1306_VERTICAL_AND_RIGHT_HORIZONTAL_SCROLL);
@@ -409,9 +418,9 @@ void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop){
 // startscrolldiagleft
 // Activate a diagonal scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F) 
+// display.scrollright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrolldiagleft(uint8_t start, uint8_t stop){
-  ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);  
+  ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);
   ssd1306_command(0X00);
   ssd1306_command(SSD1306_LCDHEIGHT);
   ssd1306_command(SSD1306_VERTICAL_AND_LEFT_HORIZONTAL_SCROLL);
@@ -473,6 +482,7 @@ void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
   }
 }
 
+#if SSD1306_SEGMENTS == 1
 void Adafruit_SSD1306::display(void) {
   ssd1306_command(SSD1306_COLUMNADDR);
   ssd1306_command(0);   // Column start address (0 = reset)
@@ -532,14 +542,86 @@ void Adafruit_SSD1306::display(void) {
   }
 }
 
+#else
+
+void Adafruit_SSD1306::render(void (*f)(void)) {
+  ssd1306_command(SSD1306_COLUMNADDR);
+  ssd1306_command(0);   // Column start address (0 = reset)
+  ssd1306_command(SSD1306_LCDWIDTH-1); // Column end address (127 = reset)
+
+  ssd1306_command(SSD1306_PAGEADDR);
+  ssd1306_command(0); // Page start address (0 = reset)
+  #if SSD1306_LCDHEIGHT == 64
+    ssd1306_command(7); // Page end address
+  #endif
+  #if SSD1306_LCDHEIGHT == 32
+    ssd1306_command(3); // Page end address
+  #endif
+  #if SSD1306_LCDHEIGHT == 16
+    ssd1306_command(1); // Page end address
+  #endif
+
+  if (sid != -1)
+  {
+    // SPI
+    *csport |= cspinmask;
+    *dcport |= dcpinmask;
+    *csport &= ~cspinmask;
+
+    for (segment = 0; segment < SSD1306_SEGMENTS; ++segment) {
+      clearDisplay();
+      f();
+      for (uint16_t i=0; i<(SSD1306_LCDWIDTH*SSD1306_LCDHEIGHT/8/SSD1306_SEGMENTS); i++) {
+        fastSPIwrite(buffer[i]);
+        //ssd1306_data(buffer[i]);
+      }
+    }
+
+    *csport |= cspinmask;
+  }
+  else
+  {
+    // save I2C bitrate
+#ifndef __SAM3X8E__
+    uint8_t twbrbackup = TWBR;
+    TWBR = 12; // upgrade to 400KHz!
+#endif
+
+    //Serial.println(TWBR, DEC);
+    //Serial.println(TWSR & 0x3, DEC);
+
+    // I2C
+    for (segment = 0; segment < SSD1306_SEGMENTS; ++segment) {
+      clearDisplay();
+      f();
+      for (uint16_t i=0; i<(SSD1306_LCDWIDTH*SSD1306_LCDHEIGHT/8/SSD1306_SEGMENTS); i++) {
+        // send a bunch of data in one xmission
+        Wire.beginTransmission(_i2caddr);
+        WIRE_WRITE(0x40);
+        for (uint8_t x=0; x<16; x++) {
+          WIRE_WRITE(buffer[i]);
+          i++;
+        }
+        i--;
+        Wire.endTransmission();
+      }
+    }
+#ifndef __SAM3X8E__
+    TWBR = twbrbackup;
+#endif
+  }
+}
+
+#endif
+
 // clear everything
 void Adafruit_SSD1306::clearDisplay(void) {
-  memset(buffer, 0, (SSD1306_LCDWIDTH*SSD1306_LCDHEIGHT/8));
+  memset(buffer, 0, (SSD1306_LCDWIDTH*SSD1306_LCDHEIGHT/8/SSD1306_SEGMENTS));
 }
 
 
 inline void Adafruit_SSD1306::fastSPIwrite(uint8_t d) {
-  
+
   if(hwSPI) {
     (void)SPI.transfer(d);
   } else {
@@ -555,7 +637,7 @@ inline void Adafruit_SSD1306::fastSPIwrite(uint8_t d) {
 
 void Adafruit_SSD1306::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) {
   boolean bSwap = false;
-  switch(rotation) { 
+  switch(rotation) {
     case 0:
       // 0 degree rotation, do nothing
       break;
@@ -580,25 +662,34 @@ void Adafruit_SSD1306::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t c
       break;
   }
 
-  if(bSwap) { 
+  if(bSwap) {
     drawFastVLineInternal(x, y, w, color);
-  } else { 
+  } else {
     drawFastHLineInternal(x, y, w, color);
   }
 }
 
+bool Adafruit_SSD1306::inSegment(int16_t y) {
+  return (y / (SSD1306_LCDHEIGHT / SSD1306_SEGMENTS)) == segment;
+}
+
+int16_t Adafruit_SSD1306::ySegmentOffset(int16_t y) {
+  return y % (SSD1306_LCDHEIGHT / SSD1306_SEGMENTS);
+}
+
 void Adafruit_SSD1306::drawFastHLineInternal(int16_t x, int16_t y, int16_t w, uint16_t color) {
   // Do bounds/limit checks
-  if(y < 0 || y >= HEIGHT) { return; }
+  if(y < 0 || y >= HEIGHT || !(inSegment(y))) { return; }
+  y = ySegmentOffset(y);
 
   // make sure we don't try to draw below 0
-  if(x < 0) { 
+  if(x < 0) {
     w += x;
     x = 0;
   }
 
   // make sure we don't go off the edge of the display
-  if( (x + w) > WIDTH) { 
+  if( (x + w) > WIDTH) {
     w = (WIDTH - x);
   }
 
@@ -614,7 +705,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(int16_t x, int16_t y, int16_t w, ui
 
   register uint8_t mask = 1 << (y&7);
 
-  switch (color) 
+  switch (color)
   {
   case WHITE:         while(w--) { *pBuf++ |= mask; }; break;
     case BLACK: mask = ~mask;   while(w--) { *pBuf++ &= mask; }; break;
@@ -624,7 +715,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(int16_t x, int16_t y, int16_t w, ui
 
 void Adafruit_SSD1306::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
   bool bSwap = false;
-  switch(rotation) { 
+  switch(rotation) {
     case 0:
       break;
     case 1:
@@ -641,14 +732,14 @@ void Adafruit_SSD1306::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t c
       y -= (h-1);
       break;
     case 3:
-      // 270 degree rotation, swap x & y for rotation, then invert y 
+      // 270 degree rotation, swap x & y for rotation, then invert y
       bSwap = true;
       swap(x, y);
       y = HEIGHT - y - 1;
       break;
   }
 
-  if(bSwap) { 
+  if(bSwap) {
     drawFastHLineInternal(x, y, h, color);
   } else {
     drawFastVLineInternal(x, y, h, color);
@@ -662,20 +753,30 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
   if(x < 0 || x >= WIDTH) { return; }
 
   // make sure we don't try to draw below 0
-  if(__y < 0) { 
+  if(__y < 0) {
     // __y is negative, this will subtract enough from __h to account for __y being 0
     __h += __y;
     __y = 0;
 
-  } 
+  }
 
   // make sure we don't go past the height of the display
-  if( (__y + __h) > HEIGHT) { 
+  if( (__y + __h) > HEIGHT) {
     __h = (HEIGHT - __y);
   }
 
-  // if our height is now negative, punt 
-  if(__h <= 0) { 
+  while (!inSegment(__y) && __h > 0) {
+    __y++;
+    __h--;
+  }
+  __y = ySegmentOffset(__y);
+
+  if (__h > SSD1306_ROWS_PER_SEGMENT) {
+    __h = SSD1306_ROWS_PER_SEGMENT;
+  }
+
+  // if our height is now negative, punt
+  if(__h <= 0) {
     return;
   }
 
@@ -694,7 +795,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
   // do the first partial byte, if necessary - this requires some masking
   register uint8_t mod = (y&7);
   if(mod) {
-    // mask off the high n bits we want to set 
+    // mask off the high n bits we want to set
     mod = 8-mod;
 
     // note - lookup table results in a nearly 10% performance improvement in fill* functions
@@ -703,17 +804,17 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
     register uint8_t mask = premask[mod];
 
     // adjust the mask if we're not going to reach the end of this byte
-    if( h < mod) { 
+    if( h < mod) {
       mask &= (0XFF >> (mod-h));
     }
 
-  switch (color) 
+  switch (color)
     {
     case WHITE:   *pBuf |=  mask;  break;
     case BLACK:   *pBuf &= ~mask;  break;
     case INVERSE: *pBuf ^=  mask;  break;
     }
-  
+
     // fast exit if we're done here!
     if(h<mod) { return; }
 
@@ -724,7 +825,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
 
 
   // write solid bytes while we can - effectively doing 8 rows at a time
-  if(h >= 8) { 
+  if(h >= 8) {
     if (color == INVERSE)  {          // separate copy of the code so we don't impact performance of the black/white write version with an extra comparison per loop
       do  {
       *pBuf=~(*pBuf);
@@ -737,7 +838,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
       } while(h >= 8);
       }
     else {
-      // store a local value to work with 
+      // store a local value to work with
       register uint8_t val = (color == WHITE) ? 255 : 0;
 
       do  {
@@ -761,7 +862,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y, int16_t __h
     // note - lookup table results in a nearly 10% performance improvement in fill* functions
     static uint8_t postmask[8] = {0x00, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F };
     register uint8_t mask = postmask[mod];
-    switch (color) 
+    switch (color)
     {
       case WHITE:   *pBuf |=  mask;  break;
       case BLACK:   *pBuf &= ~mask;  break;

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -4,14 +4,14 @@ This is a library for our Monochrome OLEDs based on SSD1306 drivers
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/category/63_98
 
-These displays use SPI to communicate, 4 or 5 pins are required to  
+These displays use SPI to communicate, 4 or 5 pins are required to
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
@@ -82,6 +82,33 @@ All text above, and the splash screen must be included in any redistribution
   #define SSD1306_LCDHEIGHT                 16
 #endif
 
+/**
+ * Defining segements to be > 1 breaks up the screen into that many segments. Each segment is rendered
+ * and drawn independently. The render function takes a function pointer and calls it for each segment,
+ * and flushes the pixels to the screen after each segment.
+ *
+ * Using this method reduces SRAM usage but decreases display speed. This is not suitable for animations
+ * or fast-refresh rate applications.
+ */
+#define SSD1306_SEGMENTS 1
+
+#if defined SSD1306_SEGMENTS
+  #if SSD1306_LCDHEIGHT % SSD1306_SEGMENTS != 0
+    #error "height % segemnets must be zero"
+  #endif
+  #if SSD1306_SEGMENTS < 1
+    #error "Segments must be positive"
+  #endif
+  #if SSD1306_SEGMENTS > SSD1306_LCDHEIGHT / 8
+    #error "The maximum number of segemnets is HEIGHT / 8"
+  #endif
+  #define SSD1306_ROWS_PER_SEGMENT SSD1306_LCDHEIGHT / SSD1306_SEGMENTS
+#else
+  // to simplify buffer manipulation code
+  #define SSD1306_SEGMENTS 1
+  #define SSD1306_ROWS_PER_SEGMENT SSD1306_LCDHEIGHT
+#endif
+
 #define SSD1306_SETCONTRAST 0x81
 #define SSD1306_DISPLAYALLON_RESUME 0xA4
 #define SSD1306_DISPLAYALLON 0xA5
@@ -140,7 +167,11 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
 
   void clearDisplay(void);
   void invertDisplay(uint8_t i);
-  void display();
+  #if SSD1306_SEGMENTS > 1
+    void render(void (*f)(void));
+  #else
+    void display();
+  #endif
 
   void startscrollright(uint8_t start, uint8_t stop);
   void startscrollleft(uint8_t start, uint8_t stop);
@@ -161,10 +192,13 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void fastSPIwrite(uint8_t c);
 
   boolean hwSPI;
+  uint8_t segment;
   PortReg *mosiport, *clkport, *csport, *dcport;
   PortMask mosipinmask, clkpinmask, cspinmask, dcpinmask;
 
   inline void drawFastVLineInternal(int16_t x, int16_t y, int16_t h, uint16_t color) __attribute__((always_inline));
   inline void drawFastHLineInternal(int16_t x, int16_t y, int16_t w, uint16_t color) __attribute__((always_inline));
 
+  inline bool inSegment(int16_t y);
+  inline int16_t ySegmentOffset(int16_t y);
 };

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -90,7 +90,9 @@ All text above, and the splash screen must be included in any redistribution
  * Using this method reduces SRAM usage but decreases display speed. This is not suitable for animations
  * or fast-refresh rate applications.
  */
-#define SSD1306_SEGMENTS 1
+#ifndef SSD1306_SEGMENTS
+  #define SSD1306_SEGMENTS 1
+#endif
 
 #if defined SSD1306_SEGMENTS
   #if SSD1306_LCDHEIGHT % SSD1306_SEGMENTS != 0


### PR DESCRIPTION
I added the ability to divide up the screen into segments so the user can choose to trade-off speed for SRAM. It's not suitable for animations but works great otherwise.

I only have a 128x64 SPI screen, so I've been unable to test on other screen sizes or interfaces but the code doesn't make any assumptions about those sizes.
