### PR TITLE
Fix definition of dim() in .h to match code in .cpp file

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -149,7 +149,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void);
 
-  void dim(uint8_t contrast);
+  void dim(boolean dim);
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 


### PR DESCRIPTION
Until now, this has been an extremely minor issue, where the .h file and .cpp file don't perfectly match.

This recent change in Arduino makes "boolean" become to "bool" rather than "uint8_t"

https://github.com/arduino/Arduino/pull/2151

Adafruit_SSD1306 breaks as a result of this previously-harmless mismatch between the .h and .cpp files.  Fortunately, the fix is very simple.