### PR TITLE
Remove pixel artifacts at start of snowing icon animation

### DIFF
--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -148,9 +148,9 @@ void setup()   {
   display.print("0x"); display.println(0xDEADBEEF, HEX);
   display.display();
   delay(2000);
+  display.clearDisplay();
 
   // miniature bitmap display
-  display.clearDisplay();
   display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
   display.display();
 
@@ -159,6 +159,7 @@ void setup()   {
   delay(1000); 
   display.invertDisplay(false);
   delay(1000); 
+  display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
   testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -159,9 +159,9 @@ void setup()   {
   display.print("0x"); display.println(0xDEADBEEF, HEX);
   display.display();
   delay(2000);
+  display.clearDisplay();
 
   // miniature bitmap display
-  display.clearDisplay();
   display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
   display.display();
 
@@ -170,6 +170,7 @@ void setup()   {
   delay(1000); 
   display.invertDisplay(false);
   delay(1000); 
+  display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
   testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -148,9 +148,9 @@ void setup()   {
   display.print("0x"); display.println(0xDEADBEEF, HEX);
   display.display();
   delay(2000);
+  display.clearDisplay();
 
   // miniature bitmap display
-  display.clearDisplay();
   display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
   display.display();
 
@@ -159,6 +159,7 @@ void setup()   {
   delay(1000); 
   display.invertDisplay(false);
   delay(1000); 
+  display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
   testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -67,7 +67,7 @@ static const unsigned char PROGMEM logo16_glcd_bmp[] =
 
 void setup()   {                
   Serial.begin(9600);
-  
+
   // by default, we'll generate the high voltage from the 3.3v line internally! (neat!)
   display.begin(SSD1306_SWITCHCAPVCC);
   // init done
@@ -146,7 +146,7 @@ void setup()   {
   testscrolltext();
   delay(2000);
   display.clearDisplay();
-  
+
   // text display tests
   display.setTextSize(1);
   display.setTextColor(WHITE);
@@ -159,9 +159,9 @@ void setup()   {
   display.print("0x"); display.println(0xDEADBEEF, HEX);
   display.display();
   delay(2000);
+  display.clearDisplay();
 
   // miniature bitmap display
-  display.clearDisplay();
   display.drawBitmap(30, 16,  logo16_glcd_bmp, 16, 16, 1);
   display.display();
 
@@ -170,6 +170,7 @@ void setup()   {
   delay(1000); 
   display.invertDisplay(false);
   delay(1000); 
+  display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
   testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);


### PR DESCRIPTION
I was noticing some pixel artifacts in the snowflake animation at the end of the test sequence. It turns out it was due to the display not being cleared.