### PR TITLE
Add include guards

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -16,6 +16,9 @@ BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
 
+#ifndef ADAFRUIT_SSD1306_H
+#define ADAFRUIT_SSD1306_H
+
 #if ARDUINO >= 100
  #include "Arduino.h"
  #define WIRE_WRITE Wire.write
@@ -168,3 +171,6 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   inline void drawFastHLineInternal(int16_t x, int16_t y, int16_t w, uint16_t color) __attribute__((always_inline));
 
 };
+
+#endif /* ADAFRUIT_SSD1306_H */
+


### PR DESCRIPTION
Ino files need include guards to be compatible with the Arduino Eclipse plugin.

See https://github.com/jantje/arduino-eclipse-plugin/issues/271