### PR TITLE
Support for SH1106

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -474,6 +474,30 @@ void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
 }
 
 void Adafruit_SSD1306::display(void) {
+
+#if defined SH1106_128_64
+    for (int index = 0; index < 8; index++) {
+        ssd1306_command(SH1106_SETSTARTPAGE + index);
+	/* for some reason display is shifted by 2 columns
+	 * on 1.3" displays from ebay
+	 */
+        ssd1306_command(SSD1306_SETLOWCOLUMN + 2); // low column start address
+        ssd1306_command(SSD1306_SETHIGHCOLUMN); // high column start address
+
+        for (int pixel = 0; pixel < SSD1306_LCDWIDTH; pixel++) {
+		Wire.beginTransmission(_i2caddr);
+		WIRE_WRITE(0x40);
+		// input buffer doesn't accept all bytes at once
+		for (uint8_t x=0; x<16; x++) {
+			WIRE_WRITE(buffer[index * SSD1306_LCDWIDTH + pixel]);
+			++pixel;
+		}
+		--pixel;
+		Wire.endTransmission();
+        }
+    }
+#else
+
   ssd1306_command(SSD1306_COLUMNADDR);
   ssd1306_command(0);   // Column start address (0 = reset)
   ssd1306_command(SSD1306_LCDWIDTH-1); // Column end address (127 = reset)
@@ -530,6 +554,8 @@ void Adafruit_SSD1306::display(void) {
     TWBR = twbrbackup;
 #endif
   }
+
+#endif
 }
 
 // clear everything

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -57,19 +57,26 @@ All text above, and the splash screen must be included in any redistribution
     SSD1306_96_16
 
     -----------------------------------------------------------------------*/
-   #define SSD1306_128_64
+   #define SH1106_128_64
+//   #define SSD1306_128_64
 //   #define SSD1306_128_32
 //   #define SSD1306_96_16
 /*=========================================================================*/
 
+
+#if defined SSD1306_128_64 && defined SH1106_128_64
+  #error "Select either SH1106 or SSD1306 display type in SSD1306.h"
+#endif
+
 #if defined SSD1306_128_64 && defined SSD1306_128_32
   #error "Only one SSD1306 display can be specified at once in SSD1306.h"
 #endif
-#if !defined SSD1306_128_64 && !defined SSD1306_128_32 && !defined SSD1306_96_16
+#if !defined SSD1306_128_64 && !defined SSD1306_128_32 && \
+    !defined SSD1306_96_16 && !defined SH1106_128_64
   #error "At least one SSD1306 display must be specified in SSD1306.h"
 #endif
 
-#if defined SSD1306_128_64
+#if defined SSD1306_128_64 || defined SH1106_128_64
   #define SSD1306_LCDWIDTH                  128
   #define SSD1306_LCDHEIGHT                 64
 #endif
@@ -118,6 +125,8 @@ All text above, and the splash screen must be included in any redistribution
 
 #define SSD1306_EXTERNALVCC 0x1
 #define SSD1306_SWITCHCAPVCC 0x2
+
+#define SH1106_SETSTARTPAGE 0xB0
 
 // Scrolling #defines
 #define SSD1306_ACTIVATE_SCROLL 0x2F

--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,5 @@
+>> Also has support for a SH1106 display driver driven by I2C. <<
+
 This is a library for our Monochrome OLEDs based on SSD1306 drivers
 
   Pick one up today in the adafruit shop!


### PR DESCRIPTION
Added support for the SH1106 controller. Demo functionality is the same except for the scrolling which doesn't seem to be supported by the driver.