### PR TITLE
Add ESP8266 hardware SPI support

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -467,15 +467,23 @@ void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
   if (sid != -1)
   {
     // SPI
-    //digitalWrite(cs, HIGH);
+    #ifdef ESP8266
+    digitalWrite(cs, HIGH);
+    digitalWrite(dc, HIGH);
+    digitalWrite(cs, LOW);
+    #else
     *csport |= cspinmask;
-    //digitalWrite(dc, HIGH);
     *dcport |= dcpinmask;
-    //digitalWrite(cs, LOW);
     *csport &= ~cspinmask;
+    #endif
+
     fastSPIwrite(c);
-    //digitalWrite(cs, HIGH);
+
+    #ifdef ESP8266
+    digitalWrite(cs, HIGH);
+    #else
     *csport |= cspinmask;
+    #endif
   }
   else
   {

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -27,7 +27,7 @@ All text above, and the splash screen below must be included in any redistributi
 
 #include <Wire.h>
 
-#include "Adafruit_GFX.h"
+// #include "Adafruit_GFX.h"
 #include "Adafruit_SSD1306.h"
 
 // the memory buffer for the LCD
@@ -113,7 +113,7 @@ void Adafruit_SSD1306::drawPixel(int16_t x, int16_t y, uint16_t color) {
   // check rotation, move pixel around if necessary
   switch (getRotation()) {
   case 1:
-    swap(x, y);
+    agswap(x, y);
     x = WIDTH - x - 1;
     break;
   case 2:
@@ -121,7 +121,7 @@ void Adafruit_SSD1306::drawPixel(int16_t x, int16_t y, uint16_t color) {
     y = HEIGHT - y - 1;
     break;
   case 3:
-    swap(x, y);
+    agswap(x, y);
     y = HEIGHT - y - 1;
     break;
   }  
@@ -607,7 +607,7 @@ void Adafruit_SSD1306::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t c
     case 1:
       // 90 degree rotation, swap x & y for rotation, then invert x
       bSwap = true;
-      swap(x, y);
+      agswap(x, y);
       x = WIDTH - x - 1;
       break;
     case 2:
@@ -619,7 +619,7 @@ void Adafruit_SSD1306::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t c
     case 3:
       // 270 degree rotation, swap x & y for rotation, then invert y  and adjust y for w (not to become h)
       bSwap = true;
-      swap(x, y);
+      agswap(x, y);
       y = HEIGHT - y - 1;
       y -= (w-1);
       break;
@@ -675,7 +675,7 @@ void Adafruit_SSD1306::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t c
     case 1:
       // 90 degree rotation, swap x & y for rotation, then invert x and adjust x for h (now to become w)
       bSwap = true;
-      swap(x, y);
+      agswap(x, y);
       x = WIDTH - x - 1;
       x -= (h-1);
       break;
@@ -688,7 +688,7 @@ void Adafruit_SSD1306::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t c
     case 3:
       // 270 degree rotation, swap x & y for rotation, then invert y 
       bSwap = true;
-      swap(x, y);
+      agswap(x, y);
       y = HEIGHT - y - 1;
       break;
   }

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -582,10 +582,17 @@ inline void Adafruit_SSD1306::fastSPIwrite(uint8_t d) {
     (void)SPI.transfer(d);
   } else {
     for(uint8_t bit = 0x80; bit; bit >>= 1) {
+      #ifdef ESP8266
+      digitalWrite(sclk, LOW);
+      if(d & bit) digitalWrite(sid, HIGH);
+      else        digitalWrite(sid, LOW);
+      digitalWrite(sclk, HIGH);
+      #else
       *clkport &= ~clkpinmask;
       if(d & bit) *mosiport |=  mosipinmask;
       else        *mosiport &= ~mosipinmask;
       *clkport |=  clkpinmask;
+      #endif
     }
   }
   //*csport |= cspinmask;

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -24,12 +24,17 @@ All text above, and the splash screen must be included in any redistribution
   #define WIRE_WRITE Wire.send
 #endif
 
+#ifdef ESP8266
+ typedef volatile uint32_t PortReg;
+ typedef uint32_t PortMask;
+#else
 #ifdef __SAM3X8E__
  typedef volatile RwReg PortReg;
  typedef uint32_t PortMask;
 #else
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;
+#endif
 #endif
 
 #include <SPI.h>

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -38,7 +38,7 @@ All text above, and the splash screen must be included in any redistribution
 #endif
 
 #include <SPI.h>
-#include <Adafruit_GFX.h>
+#include <Adafruit_mfGFX.h>
 
 #define BLACK 0
 #define WHITE 1


### PR DESCRIPTION
ESP8266 support for hardware SPI mode:
- rearrange `#include`s to be ESP8266 friendly
- uses digitalWrite instead of direct-memory access for pins
- adds `yield` around potentially expensive operations

Pins should be connected as follows:
```
     // Hardware SPI CLK (sometimes marked as "D0") = GPIO14
     // Hardware SPI MOSI (sometimes marked as "D1") = GPIO13
     // Hardware SPI MISO (not used by OLED) = GPIO12

     // CS, D/C, and RESET can be assigned freely to available GPIOs, e.g.:

     // GPIO15, pull-down 10k to GND
     #define OLED_CS 15

     // GPIO2
     #define OLED_DC 16

     // GPIO16
     #define OLED_RESET 4

     // Initialize:
     Adafruit_SSD1306 display(OLED_DC, OLED_RESET, OLED_CS);
```