### PR TITLE
allow use with other ARM chips

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -17,7 +17,7 @@ All text above, and the splash screen below must be included in any redistributi
 *********************************************************************/
 
 #include <avr/pgmspace.h>
-#if !defined(__SAM3X8E__) && !defined(ARDUINO_ARCH_SAMD)
+#if !defined(__SAM3X8E__) && !defined(ARDUINO_ARCH_SAMD) && !defined(__ARM_ARCH)
  #include <util/delay.h>
 #endif
 #include <stdlib.h>


### PR DESCRIPTION
Allow using this librariy with other ARM chips, the __SAM3X8E__ #define check is too specific.