### PR TITLE
Some cleanup, a fix for PortReg, ESP8266 fixes, ARM fixes, and more... (covers most of #25, #30, #32, #36, #39, #40)

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -24,7 +24,7 @@ All text above, and the splash screen below must be included in any redistributi
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 
-#if !defined(ARDUINO_ARCH_SAM) && !defined(ARDUINO_ARCH_SAMD) && !defined(ESP8266) && !defined(ARDUINO_ARCH_STM32F2) && !defined(ARDUINO_STM32_FEATHER)
+#if !defined(__ARM_ARCH) && !defined(ENERGIA) && !defined(ESP8266)
  #include <util/delay.h>
 #endif
 

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -554,8 +554,8 @@ void Adafruit_SSD1306::display(void) {
       Wire.beginTransmission(_i2caddr);
       WIRE_WRITE(0x40);
       for (uint8_t x=0; x<16; x++) {
-	WIRE_WRITE(buffer[i]);
-	i++;
+        WIRE_WRITE(buffer[i]);
+        i++;
       }
       i--;
       Wire.endTransmission();

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -225,114 +225,62 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     // turn on VCC (9V?)
   }
 
-   #if defined SSD1306_128_32
-    // Init sequence for 128x32 OLED module
-    ssd1306_command(SSD1306_DISPLAYOFF);                    // 0xAE
-    ssd1306_command(SSD1306_SETDISPLAYCLOCKDIV);            // 0xD5
-    ssd1306_command(0x80);                                  // the suggested ratio 0x80
+  // Init sequence
+  ssd1306_command(SSD1306_DISPLAYOFF);                    // 0xAE
+  ssd1306_command(SSD1306_SETDISPLAYCLOCKDIV);            // 0xD5
+  ssd1306_command(0x80);                                  // the suggested ratio 0x80
 
-    ssd1306_command(SSD1306_SETMULTIPLEX);                  // 0xA8
-    ssd1306_command(0x1F);
-    ssd1306_command(SSD1306_SETDISPLAYOFFSET);              // 0xD3
-    ssd1306_command(0x0);                                   // no offset
-    ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
-    ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x10); }
-    else
-      { ssd1306_command(0x14); }
-    ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
-    ssd1306_command(0x00);                                  // 0x0 act like ks0108
-    ssd1306_command(SSD1306_SEGREMAP | 0x1);
-    ssd1306_command(SSD1306_COMSCANDEC);
-    ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
-    ssd1306_command(0x02);
-    ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-    ssd1306_command(0x8F);
-    ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x22); }
-    else
-      { ssd1306_command(0xF1); }
-    ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
-    ssd1306_command(0x40);
-    ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
-    ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
-  #endif
+  ssd1306_command(SSD1306_SETMULTIPLEX);                  // 0xA8
+  ssd1306_command(SSD1306_LCDHEIGHT - 1);
 
-  #if defined SSD1306_128_64
-    // Init sequence for 128x64 OLED module
-    ssd1306_command(SSD1306_DISPLAYOFF);                    // 0xAE
-    ssd1306_command(SSD1306_SETDISPLAYCLOCKDIV);            // 0xD5
-    ssd1306_command(0x80);                                  // the suggested ratio 0x80
-    ssd1306_command(SSD1306_SETMULTIPLEX);                  // 0xA8
-    ssd1306_command(0x3F);
-    ssd1306_command(SSD1306_SETDISPLAYOFFSET);              // 0xD3
-    ssd1306_command(0x0);                                   // no offset
-    ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
-    ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x10); }
-    else
-      { ssd1306_command(0x14); }
-    ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
-    ssd1306_command(0x00);                                  // 0x0 act like ks0108
-    ssd1306_command(SSD1306_SEGREMAP | 0x1);
-    ssd1306_command(SSD1306_COMSCANDEC);
-    ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
-    ssd1306_command(0x12);
-    ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x9F); }
-    else
-      { ssd1306_command(0xCF); }
-    ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x22); }
-    else
-      { ssd1306_command(0xF1); }
-    ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
-    ssd1306_command(0x40);
-    ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
-    ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
-  #endif
+  ssd1306_command(SSD1306_SETDISPLAYOFFSET);              // 0xD3
+  ssd1306_command(0x0);                                   // no offset
+  ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
+  ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
+  if (vccstate == SSD1306_EXTERNALVCC)
+    { ssd1306_command(0x10); }
+  else
+    { ssd1306_command(0x14); }
+  ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
+  ssd1306_command(0x00);                                  // 0x0 act like ks0108
+  ssd1306_command(SSD1306_SEGREMAP | 0x1);
+  ssd1306_command(SSD1306_COMSCANDEC);
 
-  #if defined SSD1306_96_16
-    // Init sequence for 96x16 OLED module
-    ssd1306_command(SSD1306_DISPLAYOFF);                    // 0xAE
-    ssd1306_command(SSD1306_SETDISPLAYCLOCKDIV);            // 0xD5
-    ssd1306_command(0x80);                                  // the suggested ratio 0x80
-    ssd1306_command(SSD1306_SETMULTIPLEX);                  // 0xA8
-    ssd1306_command(0x0F);
-    ssd1306_command(SSD1306_SETDISPLAYOFFSET);              // 0xD3
-    ssd1306_command(0x00);                                   // no offset
-    ssd1306_command(SSD1306_SETSTARTLINE | 0x0);            // line #0
-    ssd1306_command(SSD1306_CHARGEPUMP);                    // 0x8D
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x10); }
-    else
-      { ssd1306_command(0x14); }
-    ssd1306_command(SSD1306_MEMORYMODE);                    // 0x20
-    ssd1306_command(0x00);                                  // 0x0 act like ks0108
-    ssd1306_command(SSD1306_SEGREMAP | 0x1);
-    ssd1306_command(SSD1306_COMSCANDEC);
-    ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
-    ssd1306_command(0x2);	//ada x12
-    ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x10); }
-    else
-      { ssd1306_command(0xAF); }
-    ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-    if (vccstate == SSD1306_EXTERNALVCC)
-      { ssd1306_command(0x22); }
-    else
-      { ssd1306_command(0xF1); }
-    ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
-    ssd1306_command(0x40);
-    ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
-    ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
-  #endif
+ #if defined SSD1306_128_32
+  ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
+  ssd1306_command(0x02);
+  ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
+  ssd1306_command(0x8F);
+
+#elif defined SSD1306_128_64
+  ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
+  ssd1306_command(0x12);
+  ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
+  if (vccstate == SSD1306_EXTERNALVCC)
+    { ssd1306_command(0x9F); }
+  else
+    { ssd1306_command(0xCF); }
+
+#elif defined SSD1306_96_16
+  ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
+  ssd1306_command(0x2);   //ada x12
+  ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
+  if (vccstate == SSD1306_EXTERNALVCC)
+    { ssd1306_command(0x10); }
+  else
+    { ssd1306_command(0xAF); }
+
+#endif
+
+  ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
+  if (vccstate == SSD1306_EXTERNALVCC)
+    { ssd1306_command(0x22); }
+  else
+    { ssd1306_command(0xF1); }
+  ssd1306_command(SSD1306_SETVCOMDETECT);                 // 0xDB
+  ssd1306_command(0x40);
+  ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
+  ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
 
   ssd1306_command(SSD1306_DISPLAYON);//--turn on oled panel
 }

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -414,37 +414,6 @@ void Adafruit_SSD1306::dim(boolean dim) {
   ssd1306_command(contrast);
 }
 
-void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
-  if (sid != -1)
-  {
-    // SPI
-#ifdef HAVE_PORTREG
-    *csport |= cspinmask;
-    *dcport |= dcpinmask;
-    *csport &= ~cspinmask;
-#else
-    digitalWrite(cs, HIGH);
-    digitalWrite(dc, HIGH);
-    digitalWrite(cs, LOW);
-#endif
-    fastSPIwrite(c);
-#ifdef HAVE_PORTREG
-    *csport |= cspinmask;
-#else
-    digitalWrite(cs, HIGH);
-#endif
-  }
-  else
-  {
-    // I2C
-    uint8_t control = 0x40;   // Co = 0, D/C = 1
-    Wire.beginTransmission(_i2caddr);
-    WIRE_WRITE(control);
-    WIRE_WRITE(c);
-    Wire.endTransmission();
-  }
-}
-
 void Adafruit_SSD1306::display(void) {
   ssd1306_command(SSD1306_COLUMNADDR);
   ssd1306_command(0);   // Column start address (0 = reset)
@@ -477,7 +446,6 @@ void Adafruit_SSD1306::display(void) {
 
     for (uint16_t i=0; i<(SSD1306_LCDWIDTH*SSD1306_LCDHEIGHT/8); i++) {
       fastSPIwrite(buffer[i]);
-      //ssd1306_data(buffer[i]);
     }
 #ifdef HAVE_PORTREG
     *csport |= cspinmask;

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -174,7 +174,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
   if (sid != -1){
     pinMode(dc, OUTPUT);
     pinMode(cs, OUTPUT);
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     csport      = portOutputRegister(digitalPinToPort(cs));
     cspinmask   = digitalPinToBitMask(cs);
     dcport      = portOutputRegister(digitalPinToPort(dc));
@@ -184,7 +184,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
       // set pins for software-SPI
       pinMode(sid, OUTPUT);
       pinMode(sclk, OUTPUT);
-#ifdef PortReg
+#ifdef HAVE_PORTREG
       clkport     = portOutputRegister(digitalPinToPort(sclk));
       clkpinmask  = digitalPinToBitMask(sclk);
       mosiport    = portOutputRegister(digitalPinToPort(sid));
@@ -298,7 +298,7 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
   if (sid != -1)
   {
     // SPI
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
     *dcport &= ~dcpinmask;
     *csport &= ~cspinmask;
@@ -308,7 +308,7 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
     digitalWrite(cs, LOW);
 #endif
     fastSPIwrite(c);
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
 #else
     digitalWrite(cs, HIGH);
@@ -418,7 +418,7 @@ void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
   if (sid != -1)
   {
     // SPI
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
     *dcport |= dcpinmask;
     *csport &= ~cspinmask;
@@ -428,7 +428,7 @@ void Adafruit_SSD1306::ssd1306_data(uint8_t c) {
     digitalWrite(cs, LOW);
 #endif
     fastSPIwrite(c);
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
 #else
     digitalWrite(cs, HIGH);
@@ -465,7 +465,7 @@ void Adafruit_SSD1306::display(void) {
   if (sid != -1)
   {
     // SPI
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
     *dcport |= dcpinmask;
     *csport &= ~cspinmask;
@@ -479,7 +479,7 @@ void Adafruit_SSD1306::display(void) {
       fastSPIwrite(buffer[i]);
       //ssd1306_data(buffer[i]);
     }
-#ifdef PortReg
+#ifdef HAVE_PORTREG
     *csport |= cspinmask;
 #else
     digitalWrite(cs, HIGH);
@@ -526,7 +526,7 @@ inline void Adafruit_SSD1306::fastSPIwrite(uint8_t d) {
     (void)SPI.transfer(d);
   } else {
     for(uint8_t bit = 0x80; bit; bit >>= 1) {
-#ifdef PortReg
+#ifdef HAVE_PORTREG
       *clkport &= ~clkpinmask;
       if(d & bit) *mosiport |=  mosipinmask;
       else        *mosiport &= ~mosipinmask;

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -282,6 +282,8 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
   ssd1306_command(SSD1306_DISPLAYALLON_RESUME);           // 0xA4
   ssd1306_command(SSD1306_NORMALDISPLAY);                 // 0xA6
 
+  ssd1306_command(SSD1306_DEACTIVATE_SCROLL);
+
   ssd1306_command(SSD1306_DISPLAYON);//--turn on oled panel
 }
 

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -145,7 +145,6 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
 
   void begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = SSD1306_I2C_ADDRESS, bool reset=true);
   void ssd1306_command(uint8_t c);
-  void ssd1306_data(uint8_t c);
 
   void clearDisplay(void);
   void invertDisplay(uint8_t i);

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -43,7 +43,7 @@ All text above, and the splash screen must be included in any redistribution
 #define WHITE 1
 #define INVERSE 2
 
-#define SSD1306_I2C_ADDRESS   0x3C	// 011110+SA0+RW - 0x3C or 0x3D
+#define SSD1306_I2C_ADDRESS   0x3C  // 011110+SA0+RW - 0x3C or 0x3D
 // Address for 128x32 is 0x3C
 // Address for 128x64 is 0x3D (default) or 0x3C (if SA0 is grounded)
 

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -32,6 +32,9 @@ All text above, and the splash screen must be included in any redistribution
  #define HAVE_PORTREG
 #elif defined(ARDUINO_ARCH_SAMD)
 // not supported
+#elif defined(ESP8266)
+  typedef volatile uint32_t PortReg;
+  typedef uint32_t PortMask;
 #else
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -29,11 +29,13 @@ All text above, and the splash screen must be included in any redistribution
 #if defined(__SAM3X8E__)
  typedef volatile RwReg PortReg;
  typedef uint32_t PortMask;
+ #define HAVE_PORTREG
 #elif defined(ARDUINO_ARCH_SAMD)
 // not supported
 #else
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;
+ #define HAVE_PORTREG
 #endif
 
 #include <SPI.h>
@@ -165,7 +167,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void fastSPIwrite(uint8_t c);
 
   boolean hwSPI;
-#ifdef PortReg
+#ifdef HAVE_PORTREG
   PortReg *mosiport, *clkport, *csport, *dcport;
   PortMask mosipinmask, clkpinmask, cspinmask, dcpinmask;
 #endif

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -191,14 +191,14 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
   while (1) {
     // draw each icon
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], logo16_glcd_bmp, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
     }
     display.display();
     delay(200);
     
     // then erase it + move it
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS],  logo16_glcd_bmp, w, h, BLACK);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, BLACK);
       // move it
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -203,9 +203,9 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit
       if (icons[f][YPOS] > display.height()) {
-	icons[f][XPOS] = random(display.width());
-	icons[f][YPOS] = 0;
-	icons[f][DELTAY] = random(5) + 1;
+        icons[f][XPOS] = random(display.width());
+        icons[f][YPOS] = 0;
+        icons[f][DELTAY] = random(5) + 1;
       }
     }
    }
@@ -372,4 +372,3 @@ void testscrolltext(void) {
   delay(2000);
   display.stopscroll();
 }
-

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -213,9 +213,9 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit
       if (icons[f][YPOS] > display.height()) {
-	icons[f][XPOS] = random(display.width());
-	icons[f][YPOS] = 0;
-	icons[f][DELTAY] = random(5) + 1;
+        icons[f][XPOS] = random(display.width());
+        icons[f][YPOS] = 0;
+        icons[f][DELTAY] = random(5) + 1;
       }
     }
    }
@@ -365,4 +365,3 @@ void testscrolltext(void) {
   delay(2000);
   display.stopscroll();
 }
-

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -201,14 +201,14 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
   while (1) {
     // draw each icon
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], logo16_glcd_bmp, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
     }
     display.display();
     delay(200);
     
     // then erase it + move it
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS],  logo16_glcd_bmp, w, h, BLACK);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, BLACK);
       // move it
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -202,9 +202,9 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit
       if (icons[f][YPOS] > display.height()) {
-	icons[f][XPOS] = random(display.width());
-	icons[f][YPOS] = 0;
-	icons[f][DELTAY] = random(5) + 1;
+        icons[f][XPOS] = random(display.width());
+        icons[f][YPOS] = 0;
+        icons[f][DELTAY] = random(5) + 1;
       }
     }
    }

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -190,14 +190,14 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
   while (1) {
     // draw each icon
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], logo16_glcd_bmp, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
     }
     display.display();
     delay(200);
     
     // then erase it + move it
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS],  logo16_glcd_bmp, w, h, BLACK);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, BLACK);
       // move it
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -213,9 +213,9 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit
       if (icons[f][YPOS] > display.height()) {
-	icons[f][XPOS] = random(display.width());
-	icons[f][YPOS] = 0;
-	icons[f][DELTAY] = random(5) + 1;
+        icons[f][XPOS] = random(display.width());
+        icons[f][YPOS] = 0;
+        icons[f][DELTAY] = random(5) + 1;
       }
     }
    }
@@ -365,4 +365,3 @@ void testscrolltext(void) {
   delay(2000);
   display.stopscroll();
 }
-

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -201,14 +201,14 @@ void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h) {
   while (1) {
     // draw each icon
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], logo16_glcd_bmp, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
     }
     display.display();
     delay(200);
     
     // then erase it + move it
     for (uint8_t f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS],  logo16_glcd_bmp, w, h, BLACK);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, BLACK);
       // move it
       icons[f][YPOS] += icons[f][DELTAY];
       // if its gone, reinit


### PR DESCRIPTION
This PR does multiple things:
1. It fixes some warnings (harmless, but making libraries and examples warning free is important, because it allows coders to focus on warnings generated by their own code, which can uncover real bugs)
2. Cleanup some whitespace issues
3. Refactor the display init code, to reduce code duplication. That makes it a bit easier to understand and extend the code. And it is simply a "best practice" in general.
4. Fix what I thinks is a mistake introduced by commit 5674153e88a71d8b7cf035787caa7eb06d7484df -- namely that commits seems to try to use `#ifdef` to check whether `PortReg` was typedef'd -- but that is impossible. So I try to make the code actually do what it supposedly was meant to do. However, I do not (yet) really understand what this PortReg stuff is about, so perhaps I misunderstood it somehow?

If you prefer, I can also split this into multiple PRs.