### PR TITLE
Make Library compatible with Energia

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -24,7 +24,7 @@ All text above, and the splash screen below must be included in any redistributi
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 
-#if !defined(ARDUINO_ARCH_SAM) && !defined(ARDUINO_ARCH_SAMD) && !defined(ESP8266) && !defined(ARDUINO_ARCH_STM32F2) && !defined(ARDUINO_STM32_FEATHER)
+#if !defined(ARDUINO_ARCH_SAM) && !defined(ARDUINO_ARCH_SAMD) && !defined(ESP8266) && !defined(ARDUINO_ARCH_STM32F2) && !defined(ARDUINO_STM32_FEATHER) && !defined(ENERGIA)
  #include <util/delay.h>
 #endif
 


### PR DESCRIPTION
Added a pre-processor directive to avoid AVR specific util/delay.h for Energia platform which have a built in delay routine