### PR TITLE
Save dim state and expose via public isDimmed() method. 

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -414,6 +414,13 @@ void Adafruit_SSD1306::dim(boolean dim) {
   // it is useful to dim the display
   ssd1306_command(SSD1306_SETCONTRAST);
   ssd1306_command(contrast);
+
+  // save the dim state, exposed via public getter method isDimmed()
+  _isDimmed = dim;
+}
+
+bool Adafruit_SSD1306::isDimmed() {
+    return _isDimmed;
 }
 
 void Adafruit_SSD1306::display(void) {

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -158,6 +158,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void stopscroll(void);
 
   void dim(boolean dim);
+  bool isDimmed();
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 
@@ -173,6 +174,8 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   PortReg *mosiport, *clkport, *csport, *dcport;
   PortMask mosipinmask, clkpinmask, cspinmask, dcpinmask;
 #endif
+
+  bool _isDimmed = false;
 
   inline void drawFastVLineInternal(int16_t x, int16_t y, int16_t h, uint16_t color) __attribute__((always_inline));
   inline void drawFastHLineInternal(int16_t x, int16_t y, int16_t w, uint16_t color) __attribute__((always_inline));


### PR DESCRIPTION
Useful when adjusting screen brightness at runtime based on photo sensor value. Getting the saved value each Loop() cycle to decide whether to (un)dim is cheaper than calling the dim() method each cycle regardless.

If this feature is considered to be not generic enough for this library, I'm happy to keep the change just for myself (in that case just ignore this pull request).
