### PR TITLE
Wire.set clock plus

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -208,6 +208,8 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     // Force 400 KHz I2C, rawr! (Uses pins 20, 21 for SDA, SCL)
     TWI1->TWI_CWGR = 0;
     TWI1->TWI_CWGR = ((VARIANT_MCK / (2 * 400000)) - 4) * 0x101;
+#elif ARDUINO >= 157
+    Wire.setClock(400000UL); // Set I2C frequency to 400kHz
 #endif
   }
   if ((reset) && (rst >= 0)) {

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -22,6 +22,11 @@ All text above, and the splash screen must be included in any redistribution
 #include <Adafruit_SSD1306.h>
 
 #define OLED_RESET 4
+
+// Define your displays I2C address.  Only define one. 
+#define SSD_I2C_ADDR 0x3D   // On some displays may be marked 0x7a as 0x7a>>1 = 0x3d
+//#define SSD_I2C_ADDR 0x3C   // on some displays may be marked 0x78 as 0x78>>1 = 0x3c 
+
 Adafruit_SSD1306 display(OLED_RESET);
 
 #define NUMFLAKES 10
@@ -58,7 +63,7 @@ void setup()   {
   Serial.begin(9600);
 
   // by default, we'll generate the high voltage from the 3.3v line internally! (neat!)
-  display.begin(SSD1306_SWITCHCAPVCC, 0x3D);  // initialize with the I2C addr 0x3D (for the 128x64)
+  display.begin(SSD1306_SWITCHCAPVCC, SSD_I2C_ADDR);  // initialize with the I2C addr 0x3D (for the 128x64)
   // init done
   
   // Show image buffer on the display hardware.


### PR DESCRIPTION
These changes are specific to I2c setups. 

The main change was if your arduino version is >= 1.5.7 the call Wire.setClock(4000000L);
This is done in the begin function as an elif to the Arduino due code to do similar. 

Tested on Beta Teensy 3.x board, and verified with Saleae Logic Analyzer. 

Also as an optional change, I changed the I2C (128x64) version to add defines to .ino file for the two possible i2C addresses with comments that also show the 8 bit to 7 bit translation.  I did this as my display came with address 0x7c instead of 0x7d, which took me a bit of time to figure out why my display was not outputting anything. 