### PR TITLE
Add support for 64x32 displays + higher speed I2C com

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -67,14 +67,15 @@ All text above, and the splash screen must be included in any redistribution
 
     -----------------------------------------------------------------------*/
 //   #define SSD1306_128_64
-   #define SSD1306_128_32
+//   #define SSD1306_128_32
 //   #define SSD1306_96_16
+   #define  SSD1306_64_32
 /*=========================================================================*/
 
 #if defined SSD1306_128_64 && defined SSD1306_128_32
   #error "Only one SSD1306 display can be specified at once in SSD1306.h"
 #endif
-#if !defined SSD1306_128_64 && !defined SSD1306_128_32 && !defined SSD1306_96_16
+#if !defined SSD1306_128_64 && !defined SSD1306_128_32 && !defined SSD1306_96_16 && !defined SSD1306_64_32
   #error "At least one SSD1306 display must be specified in SSD1306.h"
 #endif
 
@@ -89,6 +90,10 @@ All text above, and the splash screen must be included in any redistribution
 #if defined SSD1306_96_16
   #define SSD1306_LCDWIDTH                  96
   #define SSD1306_LCDHEIGHT                 16
+#endif
+#if defined SSD1306_64_32
+  #define SSD1306_LCDWIDTH                  64
+  #define SSD1306_LCDHEIGHT                 32
 #endif
 
 #define SSD1306_SETCONTRAST 0x81


### PR DESCRIPTION
New define has been setup for 64x32 displays that need an additional
starting offset value of 0x20 + the other usual changes.. Only currently
tested on 64x32 and 128x64 displays on a SAMD core board.