### PR TITLE
Fixes includes/defines for Intel Curie (Arduino 101)

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -24,7 +24,7 @@ All text above, and the splash screen below must be included in any redistributi
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 
-#if !defined(__ARM_ARCH) && !defined(ENERGIA) && !defined(ESP8266)
+#if !defined(__ARM_ARCH) && !defined(ENERGIA) && !defined(ESP8266) && !defined(__arc__)
  #include <util/delay.h>
 #endif
 

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -32,7 +32,7 @@ All text above, and the splash screen must be included in any redistribution
  #define HAVE_PORTREG
 #elif defined(ARDUINO_ARCH_SAMD)
 // not supported
-#elif defined(ESP8266) || defined(ARDUINO_STM32_FEATHER)
+#elif defined(ESP8266) || defined(ARDUINO_STM32_FEATHER) || defined(__arc__)
   typedef volatile uint32_t PortReg;
   typedef uint32_t PortMask;
 #else

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ATSAM3X8E          |      X       |             |            |
 ATSAM21D           |      X       |             |            | 
 ATtiny85 @ 16MHz   |             |      X       |            | 
 ATtiny85 @ 8MHz    |             |      X       |            | 
-Intel Curie @ 32MHz |             |             |     X       | 
+Intel Curie @ 32MHz |      X      |              |            | 
 STM32F2            |             |             |     X       | 
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini


### PR DESCRIPTION
Adds preprocessor defines to support Intel Curie (Arduino 101) and also updates README of supported platforms.

Resolves #70.
