### PR TITLE
Extracting HW specific code to a driver class

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@
 
 MCU                | Tested Works | Doesn't Work | Not Tested  | Notes
 ------------------ | :----------: | :----------: | :---------: | -----
-Atmega328 @ 16MHz  |      X       |             |            | 
-Atmega328 @ 12MHz  |      X       |             |            | 
-Atmega32u4 @ 16MHz |      X       |             |            | 
-Atmega32u4 @ 8MHz  |      X       |             |            | 
-ESP8266            |      X       |             |            | change OLED_RESET to different pin if using default I2C pins D4/D5.
-Atmega2560 @ 16MHz |      X       |             |            | 
-ATSAM3X8E          |      X       |             |            | 
-ATSAM21D           |      X       |             |            | 
-ATtiny85 @ 16MHz   |             |      X       |            | 
-ATtiny85 @ 8MHz    |             |      X       |            | 
-Intel Curie @ 32MHz |             |             |     X       | 
-STM32F2            |             |             |     X       | 
+Atmega328 @ 16MHz  |      X       |              |             | 
+Atmega328 @ 12MHz  |      X       |              |             | 
+Atmega32u4 @ 16MHz |      X       |              |             | 
+Atmega32u4 @ 8MHz  |      X       |              |             | 
+ESP8266            |      X       |              |             | change OLED_RESET to different pin if using default I2C pins D4/D5.
+Atmega2560 @ 16MHz |      X       |              |             | 
+ATSAM3X8E          |      X       |              |             | 
+ATSAM21D           |      X       |              |             | 
+ATtiny85 @ 16MHz   |              |      X       |             | 
+ATtiny85 @ 8MHz    |              |      X       |             | 
+Intel Curie @ 32MHz |             |              |     X       | 
+STM32F1            |      X       |              |             | Tested with STM32GENERIC and stm32duino
+STM32F2            |              |              |     X       | 
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
@@ -28,5 +29,6 @@ STM32F2            |             |             |     X       |
   * ATSAM21D : Arduino Zero, M0 Pro
   * ATtiny85 @ 16MHz : Adafruit Trinket 5V
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
+  * STM32F1: Blue Pill board (STM32F103C8)
 
 <!-- END COMPATIBILITY TABLE -->

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -23,7 +23,7 @@ All text above, and the splash screen must be included in any redistribution
 #include <ssd1306_i2c_driver.h>
 
 #define OLED_RESET 4
-SSD1306_I2C_Driver i2c_driver;
+SSD1306_I2C_Driver i2c_driver(0x3C);    // initialize with the I2C addr 0x3C (for the 128x32)
 Adafruit_SSD1306 display(&i2c_driver, OLED_RESET);
 
 #define NUMFLAKES 10
@@ -60,7 +60,7 @@ void setup()   {
   Serial.begin(9600);
 
   // by default, we'll generate the high voltage from the 3.3v line internally! (neat!)
-  display.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)
+  display.begin(SSD1306_SWITCHCAPVCC);
   // init done
   
   // Show image buffer on the display hardware.

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -20,9 +20,11 @@ All text above, and the splash screen must be included in any redistribution
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
+#include <ssd1306_i2c_driver.h>
 
 #define OLED_RESET 4
-Adafruit_SSD1306 display(OLED_RESET);
+SSD1306_I2C_Driver i2c_driver;
+Adafruit_SSD1306 display(&i2c_driver, OLED_RESET);
 
 #define NUMFLAKES 10
 #define XPOS 0

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -21,20 +21,24 @@ All text above, and the splash screen must be included in any redistribution
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 
-// If using software SPI (the default case):
+// If using sowtware software SPI (the default case):
+#include <ssd1306_sw_spi_driver.h>
 #define OLED_MOSI   9
 #define OLED_CLK   10
 #define OLED_DC    11
 #define OLED_CS    12
 #define OLED_RESET 13
-Adafruit_SSD1306 display(OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
+SSD1306_SW_SPI_Driver spi_driver(OLED_MOSI, OLED_CLK, OLED_DC, OLED_CS);
 
 /* Uncomment this block to use hardware SPI
+#include <ssd1306_spi_driver.h>
 #define OLED_DC     6
 #define OLED_CS     7
 #define OLED_RESET  8
-Adafruit_SSD1306 display(OLED_DC, OLED_RESET, OLED_CS);
+SSD1306_SPI_Driver spi_driver(OLED_DC, OLED_CS);
 */
+
+Adafruit_SSD1306 display(&spi_driver, OLED_RESET);
 
 #define NUMFLAKES 10
 #define XPOS 0

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -20,9 +20,11 @@ All text above, and the splash screen must be included in any redistribution
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
+#include <ssd1306_i2c_driver.h>
 
 #define OLED_RESET 4
-Adafruit_SSD1306 display(OLED_RESET);
+SSD1306_I2C_Driver i2c_driver;
+Adafruit_SSD1306 display(&i2c_driver, OLED_RESET);
 
 #define NUMFLAKES 10
 #define XPOS 0

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -23,7 +23,7 @@ All text above, and the splash screen must be included in any redistribution
 #include <ssd1306_i2c_driver.h>
 
 #define OLED_RESET 4
-SSD1306_I2C_Driver i2c_driver;
+SSD1306_I2C_Driver i2c_driver(0x3D); // initialize with the I2C addr 0x3D (for the 128x64)
 Adafruit_SSD1306 display(&i2c_driver, OLED_RESET);
 
 #define NUMFLAKES 10
@@ -60,7 +60,7 @@ void setup()   {
   Serial.begin(9600);
 
   // by default, we'll generate the high voltage from the 3.3v line internally! (neat!)
-  display.begin(SSD1306_SWITCHCAPVCC, 0x3D);  // initialize with the I2C addr 0x3D (for the 128x64)
+  display.begin(SSD1306_SWITCHCAPVCC);
   // init done
   
   // Show image buffer on the display hardware.

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -21,20 +21,25 @@ All text above, and the splash screen must be included in any redistribution
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 
-// If using software SPI (the default case):
+// If using sowtware software SPI (the default case):
+#include <ssd1306_sw_spi_driver.h>
 #define OLED_MOSI   9
 #define OLED_CLK   10
 #define OLED_DC    11
 #define OLED_CS    12
 #define OLED_RESET 13
-Adafruit_SSD1306 display(OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
+SSD1306_SW_SPI_Driver spi_driver(OLED_MOSI, OLED_CLK, OLED_DC, OLED_CS);
 
 /* Uncomment this block to use hardware SPI
+#include <ssd1306_spi_driver.h>
 #define OLED_DC     6
 #define OLED_CS     7
 #define OLED_RESET  8
-Adafruit_SSD1306 display(OLED_DC, OLED_RESET, OLED_CS);
+SSD1306_SPI_Driver spi_driver(OLED_DC, OLED_CS);
 */
+
+Adafruit_SSD1306 display(&spi_driver, OLED_RESET);
+
 
 #define NUMFLAKES 10
 #define XPOS 0

--- a/ssd1306_i2c_driver.cpp
+++ b/ssd1306_i2c_driver.cpp
@@ -1,0 +1,64 @@
+#include <Wire.h>
+
+#if ARDUINO >= 100
+#include "Arduino.h"
+#define WIRE_WRITE Wire.write
+#else
+#include "WProgram.h"
+#define WIRE_WRITE Wire.send
+#endif
+
+#include "ssd1306_i2c_driver.h"
+
+SSD1306_I2C_Driver::SSD1306_I2C_Driver(int8_t i2caddr)
+{
+	_i2caddr = i2caddr;
+}
+
+void SSD1306_I2C_Driver::begin()
+{
+	// I2C Init
+	Wire.begin();
+
+#ifdef __SAM3X8E__
+	// Force 400 KHz I2C, rawr! (Uses pins 20, 21 for SDA, SCL)
+	TWI1->TWI_CWGR = 0;
+	TWI1->TWI_CWGR = ((VARIANT_MCK / (2 * 400000)) - 4) * 0x101;
+#endif
+}
+
+void SSD1306_I2C_Driver::sendCommand(uint8_t cmd)
+{
+	uint8_t control = 0x00;   // Co = 0, D/C = 0
+	Wire.beginTransmission(_i2caddr);
+	Wire.write(control);
+	Wire.write(cmd);
+	Wire.endTransmission();
+}
+
+void SSD1306_I2C_Driver::sendData(uint8_t * data, size_t size)
+{
+	// save I2C bitrate
+#ifdef TWBR
+	uint8_t twbrbackup = TWBR;
+	TWBR = 12; // upgrade to 400KHz!
+#endif
+
+	for (uint16_t i=0; i<size; i++)
+	{
+		// send a bunch of data in one xmission
+		Wire.beginTransmission(_i2caddr);
+		WIRE_WRITE(0x40);
+		for (uint8_t x=0; x<16; x++)
+		{
+			WIRE_WRITE(data[i]);
+			i++;
+		}
+		i--;
+		Wire.endTransmission();
+	}
+
+#ifdef TWBR
+	TWBR = twbrbackup;
+#endif
+}

--- a/ssd1306_i2c_driver.h
+++ b/ssd1306_i2c_driver.h
@@ -1,0 +1,23 @@
+#ifndef SSD1306_I2C_DRIVER_H
+#define SSD1306_I2C_DRIVER_H
+
+#include "Adafruit_SSD1306.h"
+
+#define SSD1306_I2C_ADDRESS   0x3C  // 011110+SA0+RW - 0x3C or 0x3D
+// Address for 128x32 is 0x3C
+// Address for 128x64 is 0x3D (default) or 0x3C (if SA0 is grounded)
+
+class SSD1306_I2C_Driver : public ISSD1306Driver
+{
+	// address of the display on I2C bus
+	int8_t _i2caddr;
+
+public:
+	SSD1306_I2C_Driver(int8_t i2caddr = SSD1306_I2C_ADDRESS);
+
+	virtual void begin();
+	virtual void sendCommand(uint8_t cmd);
+	virtual void sendData(uint8_t * data, size_t size);
+};
+
+#endif // SSD1306_I2C_DRIVER_H

--- a/ssd1306_spi_driver.cpp
+++ b/ssd1306_spi_driver.cpp
@@ -1,0 +1,75 @@
+#include <SPI.h>
+
+#include "ssd1306_spi_driver.h"
+
+SSD1306_SPI_Driver::SSD1306_SPI_Driver(int8_t DC, int8_t CS)
+{
+	dc = DC;
+	cs = CS;
+}
+
+void SSD1306_SPI_Driver::begin()
+{
+	// set pin directions
+	pinMode(dc, OUTPUT);
+	pinMode(cs, OUTPUT);
+
+#ifdef HAVE_PORTREG
+	csport      = portOutputRegister(digitalPinToPort(cs));
+	cspinmask   = digitalPinToBitMask(cs);
+	dcport      = portOutputRegister(digitalPinToPort(dc));
+	dcpinmask   = digitalPinToBitMask(dc);
+#endif
+
+	// Set up SPI peripheral
+	SPI.begin();
+
+#ifdef SPI_HAS_TRANSACTION
+	SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
+#else
+	SPI.setClockDivider (4);
+#endif
+}
+
+void SSD1306_SPI_Driver::sendCommand(uint8_t cmd)
+{
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+	*dcport &= ~dcpinmask;
+	*csport &= ~cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+	digitalWrite(dc, LOW);
+	digitalWrite(cs, LOW);
+#endif
+
+	(void)SPI.transfer(cmd);
+
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+#endif
+}
+
+void SSD1306_SPI_Driver::sendData(uint8_t * data, size_t size)
+{
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+	*dcport |= dcpinmask;
+	*csport &= ~cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+	digitalWrite(dc, HIGH);
+	digitalWrite(cs, LOW);
+#endif
+
+	for (uint16_t i=0; i<size; i++)
+		(void)SPI.transfer(data[size]);
+
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+#endif
+}

--- a/ssd1306_spi_driver.h
+++ b/ssd1306_spi_driver.h
@@ -1,0 +1,39 @@
+#ifndef SSD1306_SPI_DRIVER_H
+#define SSD1306_SPI_DRIVER_H
+
+#include "Adafruit_SSD1306.h"
+
+#if defined(__SAM3X8E__)
+	typedef volatile RwReg PortReg;
+	typedef uint32_t PortMask;
+	#define HAVE_PORTREG
+#elif defined(__AVR__)
+	typedef volatile uint8_t PortReg;
+	typedef uint8_t PortMask;
+	#define HAVE_PORTREG
+#elif defined(ARDUINO_ARCH_SAMD)
+	// not supported
+#elif defined(ESP8266) || defined(ESP32) || defined(ARDUINO_STM32_FEATHER) || defined(__arc__)
+	typedef volatile uint32_t PortReg;
+	typedef uint32_t PortMask;
+#endif
+
+class SSD1306_SPI_Driver : public ISSD1306Driver
+{
+	// SPI connection use standard MOSI and SCLK pins plus Data/Command and Chip Select pins
+	int8_t dc, cs;
+
+#ifdef HAVE_PORTREG
+	PortReg *csport, *dcport;
+	PortMask cspinmask, dcpinmask;
+#endif
+
+public:
+	SSD1306_SPI_Driver(int8_t DC, int8_t CS);
+
+	virtual void begin();
+	virtual void sendCommand(uint8_t cmd);
+	virtual void sendData(uint8_t * data, size_t size);
+};
+
+#endif // SSD1306_SPI_DRIVER_H

--- a/ssd1306_sw_spi_driver.cpp
+++ b/ssd1306_sw_spi_driver.cpp
@@ -1,0 +1,90 @@
+#include "ssd1306_sw_spi_driver.h"
+
+SSD1306_SW_SPI_Driver::SSD1306_SW_SPI_Driver(int8_t SID, int8_t SCLK, int8_t DC, int8_t CS)
+{
+	dc = DC;
+	cs = CS;
+	sclk = SCLK;
+	sid = SID;
+}
+
+void SSD1306_SW_SPI_Driver::begin()
+{
+	// set pin directions
+	pinMode(dc, OUTPUT);
+	pinMode(cs, OUTPUT);
+	pinMode(sid, OUTPUT);
+	pinMode(sclk, OUTPUT);
+
+#ifdef HAVE_PORTREG
+	csport      = portOutputRegister(digitalPinToPort(cs));
+	cspinmask   = digitalPinToBitMask(cs);
+	dcport      = portOutputRegister(digitalPinToPort(dc));
+	dcpinmask   = digitalPinToBitMask(dc);
+	clkport     = portOutputRegister(digitalPinToPort(sclk));
+	clkpinmask  = digitalPinToBitMask(sclk);
+	mosiport    = portOutputRegister(digitalPinToPort(sid));
+	mosipinmask = digitalPinToBitMask(sid);
+#endif
+}
+
+inline void SSD1306_SW_SPI_Driver::fastSPIwrite(uint8_t d)
+{
+	for(uint8_t bit = 0x80; bit; bit >>= 1)
+	{
+#ifdef HAVE_PORTREG
+		*clkport &= ~clkpinmask;
+		if(d & bit) *mosiport |=  mosipinmask;
+		else        *mosiport &= ~mosipinmask;
+		*clkport |=  clkpinmask;
+#else
+		digitalWrite(sclk, LOW);
+		if(d & bit) digitalWrite(sid, HIGH);
+		else        digitalWrite(sid, LOW);
+		digitalWrite(sclk, HIGH);
+#endif
+	}
+}
+
+void SSD1306_SW_SPI_Driver::sendCommand(uint8_t cmd)
+{
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+	*dcport &= ~dcpinmask;
+	*csport &= ~cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+	digitalWrite(dc, LOW);
+	digitalWrite(cs, LOW);
+#endif
+
+	fastSPIwrite(cmd);
+
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+#endif
+}
+
+void SSD1306_SW_SPI_Driver::sendData(uint8_t * data, size_t size)
+{
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+	*dcport |= dcpinmask;
+	*csport &= ~cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+	digitalWrite(dc, HIGH);
+	digitalWrite(cs, LOW);
+#endif
+
+	for (uint16_t i=0; i<size; i++)
+		fastSPIwrite(data[i]);
+
+#ifdef HAVE_PORTREG
+	*csport |= cspinmask;
+#else
+	digitalWrite(cs, HIGH);
+#endif
+}

--- a/ssd1306_sw_spi_driver.h
+++ b/ssd1306_sw_spi_driver.h
@@ -1,0 +1,41 @@
+#ifndef SSD1306_SW_SPI_DRIVER_H
+#define SSD1306_SW_SPI_DRIVER_H
+
+#include "Adafruit_SSD1306.h"
+
+#if defined(__SAM3X8E__)
+	typedef volatile RwReg PortReg;
+	typedef uint32_t PortMask;
+	#define HAVE_PORTREG
+#elif defined(__AVR__)
+	typedef volatile uint8_t PortReg;
+	typedef uint8_t PortMask;
+	#define HAVE_PORTREG
+#elif defined(ARDUINO_ARCH_SAMD)
+	// not supported
+#elif defined(ESP8266) || defined(ESP32) || defined(ARDUINO_STM32_FEATHER) || defined(__arc__)
+	typedef volatile uint32_t PortReg;
+	typedef uint32_t PortMask;
+#endif
+
+class SSD1306_SW_SPI_Driver : public ISSD1306Driver
+{
+	// SPI connection use standard MOSI and SCLK pins plus Data/Command and Chip Select pins
+	int8_t sid, sclk, dc, cs;
+
+#ifdef HAVE_PORTREG
+	PortReg *mosiport, *clkport, *csport, *dcport;
+	PortMask mosipinmask, clkpinmask, cspinmask, dcpinmask;
+#endif
+
+	void fastSPIwrite(uint8_t c);
+
+public:
+	SSD1306_SW_SPI_Driver(int8_t SID, int8_t SCLK, int8_t DC, int8_t CS);
+
+	virtual void begin();
+	virtual void sendCommand(uint8_t cmd);
+	virtual void sendData(uint8_t * data, size_t size);
+};
+
+#endif // SSD1306_SPI_DRIVER_H


### PR DESCRIPTION
I wanted to add custom low level code into I2C communication. For instance I would like to use DMA to transfer data (I am on STM32). 

Unfortunately the library design does not allow me to alter behavior. All SPI, software SPI and I2C code is mixed. I already did an attempt to clean this up (https://github.com/adafruit/Adafruit_SSD1306/pull/85). But this time I did not want to add more defines there. Moreover I want to create my own custom driver that will probably use external features (such as FreeRTOS synchronization)

So I created ISSD1306Driver interface. Objects that implement this interface encapsulate all the work with hardware. At the same time Adafruit_SSD1306 class does not know anything of hardware, instead it use the driver to send data to the display.

I moved 3 existing drivers to separate classes. Usage is slightly changed, but now it is a little cleaner. Should not be a big deal even for arduino/c++ newbies.

I did not change any functionality. Only code moves.

I tested the change on STM32F1, based on STM32GENERIC arduino port. I am using I2C,
I did not check SPI communication as I do not have such display. Though it compiled fine