### PR TITLE
Set I2C clock to 1MHz for Adafruit Feather M0 (And presumably Arduino Zero)

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -204,6 +204,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
   {
     // I2C Init
     Wire.begin();
+#ifdef ARDUINO_SAMD_ZERO
+    Wire.setClock(1000000u); // Fast mode plus: 1MHz
+#endif
 #ifdef __SAM3X8E__
     // Force 400 KHz I2C, rawr! (Uses pins 20, 21 for SDA, SCL)
     TWI1->TWI_CWGR = 0;


### PR DESCRIPTION
Changed from the default I2C clock (100KHz ?) to 1MHz for SAMD Zero boards. Tested with an Adafruit Feather M0 Adalogger and an Adafruit FeatherWing OLED. I did try 3.4MHz but that speed didn't work.

See: https://www.arduino.cc/en/Reference/WireSetClock