### PR TITLE
Properly implement SPI transactions

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -296,6 +296,17 @@ void Adafruit_SSD1306::invertDisplay(uint8_t i) {
   }
 }
 
+void Adafruit_SSD1306::displayOn()
+{
+    ssd1306_command(SSD1306_DISPLAYON);
+}
+
+void Adafruit_SSD1306::displayOff()
+{
+    ssd1306_command(SSD1306_DISPLAYOFF);
+}
+
+
 void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
   if (sid != -1)
   {

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -193,9 +193,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
       }
     if (hwSPI){
       SPI.begin();
-#ifdef SPI_HAS_TRANSACTION
-      SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
-#else
+#ifndef SPI_HAS_TRANSACTION
       SPI.setClockDivider (4);
 #endif
     }
@@ -310,6 +308,9 @@ void Adafruit_SSD1306::displayOff()
 void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
   if (sid != -1)
   {
+#ifdef SPI_HAS_TRANSACTION
+    SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
+#endif
     // SPI
 #ifdef HAVE_PORTREG
     *csport |= cspinmask;
@@ -326,6 +327,10 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
 #else
     digitalWrite(cs, HIGH);
 #endif
+
+#ifdef SPI_HAS_TRANSACTION
+    SPI.endTransaction();
+#endif    
   }
   else
   {
@@ -446,6 +451,9 @@ void Adafruit_SSD1306::display(void) {
 
   if (sid != -1)
   {
+#ifdef SPI_HAS_TRANSACTION
+    SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
+#endif
     // SPI
 #ifdef HAVE_PORTREG
     *csport |= cspinmask;
@@ -465,6 +473,10 @@ void Adafruit_SSD1306::display(void) {
 #else
     digitalWrite(cs, HIGH);
 #endif
+
+#ifdef SPI_HAS_TRANSACTION
+    SPI.endTransaction();
+#endif    
   }
   else
   {

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -70,8 +70,8 @@ All text above, and the splash screen must be included in any redistribution
     SSD1306_96_16
 
     -----------------------------------------------------------------------*/
-//   #define SSD1306_128_64
-   #define SSD1306_128_32
+   #define SSD1306_128_64
+//   #define SSD1306_128_32
 //   #define SSD1306_96_16
 /*=========================================================================*/
 
@@ -153,6 +153,9 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void clearDisplay(void);
   void invertDisplay(uint8_t i);
   void display();
+
+  void displayOn();
+  void displayOff();
 
   void startscrollright(uint8_t start, uint8_t stop);
   void startscrollleft(uint8_t start, uint8_t stop);


### PR DESCRIPTION
Hihi Adafruit Team!

I am working on a [clock](https://twitter.com/makeitblink42/status/900139137705156609) for my daughter and discovered that the SSD1306 was crashing when other SPI-based peripherals were active. On further investigation, I discovered that the beginTransaction() / endTransaction() API was not 100% properly implemented. (You are supposed to call this pair around every SPI.transfer() operation but the library only calls it once.) This means the library would work well when the SSD1306 was the only device being driven.

This pull request properly surrounds SPI.transfer() with the proper calls. It allows my project to simultaneously write to the display AND read sounds from a flash chip AND drive neopixels.

I have tested it on a Teensy 3.1. If you guys have a good regression test suite and can test it on more hardware would be interested to hear if it works. 

As a bonus, I have added some code that disables/enables the display for power conservation purposes.

Enjoy!