### PR TITLE
Correct scroll method comments

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -330,7 +330,7 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
 // startscrollright
 // Activate a right handed scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F)
+// display.startscrollright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_RIGHT_HORIZONTAL_SCROLL);
   ssd1306_command(0X00);
@@ -343,9 +343,9 @@ void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop){
 }
 
 // startscrollleft
-// Activate a right handed scroll for rows start through stop
+// Activate a left handed scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F)
+// display.startscrollleft(0x00, 0x0F)
 void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_LEFT_HORIZONTAL_SCROLL);
   ssd1306_command(0X00);
@@ -358,9 +358,9 @@ void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop){
 }
 
 // startscrolldiagright
-// Activate a diagonal scroll for rows start through stop
+// Activate a right handed diagonal scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F)
+// display.startscrolldiagright(0x00, 0x0F)
 void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);
   ssd1306_command(0X00);
@@ -375,9 +375,9 @@ void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop){
 }
 
 // startscrolldiagleft
-// Activate a diagonal scroll for rows start through stop
+// Activate a left handed diagonal scroll for rows start through stop
 // Hint, the display is 16 rows tall. To scroll the whole display, run:
-// display.scrollright(0x00, 0x0F)
+// display.startscrolldiagleft(0x00, 0x0F)
 void Adafruit_SSD1306::startscrolldiagleft(uint8_t start, uint8_t stop){
   ssd1306_command(SSD1306_SET_VERTICAL_SCROLL_AREA);
   ssd1306_command(0X00);


### PR DESCRIPTION
Scope: this commit only changes comments.

I've only made the method names in the comments match that of the method it is above, and corrected left/right statements.

While the comments say the display is 16 rows tall, my understanding is that the 128x64 display is 8 pages tall (`64/8==8`) while the 128x32 is 4 pages tall and the 16px high display has 2 pages. If this is correct I can change the comment to match the number of pages as seen around [line 427](https://github.com/seth10/Adafruit_SSD1306/blob/ff1cb0d169fce3b407f117fec5a6d3eb6a82ec6a/Adafruit_SSD1306.cpp#L427), in the `display` method.