### PR TITLE
Swap the argument order to that expected by the function.

### DIFF
--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -163,7 +163,7 @@ void setup()   {
   display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
-  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);
+  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
 }
 
 

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -173,7 +173,7 @@ void setup()   {
   display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
-  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);
+  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
 }
 
 

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -163,7 +163,7 @@ void setup()   {
   display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
-  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);
+  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
 }
 
 

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -173,7 +173,7 @@ void setup()   {
   display.clearDisplay();
 
   // draw a bitmap icon and 'animate' movement
-  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);
+  testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_WIDTH, LOGO16_GLCD_HEIGHT);
 }
 
 


### PR DESCRIPTION
The order of the passed arguments is incorrect.  Just a few lines later the function is defined as:
void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h)

So all that this does is swap the height and width arguments.

Ended up finding this by using a non-square image.