### PR TITLE
Use 400 kHz mode on 32 bit Teensy boards

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -209,6 +209,9 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
     TWI1->TWI_CWGR = 0;
     TWI1->TWI_CWGR = ((VARIANT_MCK / (2 * 400000)) - 4) * 0x101;
 #endif
+#if defined(__arm__) && defined(TEENSYDUINO)
+    Wire.setClock(400000);
+#endif
   }
   if ((reset) && (rst >= 0)) {
     // Setup reset pin direction (used by both SPI and I2C)


### PR DESCRIPTION
This enables 400 kHz I2C, same as used for Arduino Due.

Should be very safe, since it's surrounded by ifdefs that won't affect any other boards.