### PR TITLE
Fix the parameter type of Adafruit_SSD1306::invertDisplay.

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -288,7 +288,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
 }
 
 
-void Adafruit_SSD1306::invertDisplay(uint8_t i) {
+void Adafruit_SSD1306::invertDisplay(boolean i) {
   if (i) {
     ssd1306_command(SSD1306_INVERTDISPLAY);
   } else {

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -151,7 +151,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void ssd1306_command(uint8_t c);
 
   void clearDisplay(void);
-  void invertDisplay(uint8_t i);
+  void invertDisplay(boolean i);
   void display();
 
   void startscrollright(uint8_t start, uint8_t stop);


### PR DESCRIPTION
Change invertDisplay(uint8_t) to invertDisplay(boolean) to match the virtual function signature in the GFX base class so that it really overrides. The uint8_t was interpreted as a boolean anyway so there's no semantic change.

```
Adafruit_SSD1306 oled;
Adafruit_GFX& gfx = oled;
oled.invertDisplay(true);   // calls Adafruit_SSD1306::invertDisplay.
gfx.invertDisplay(true);  // oops! calls noop Adafruit_GFX::invertDisplay.
```

https://github.com/adafruit/Adafruit-GFX-Library/blob/master/Adafruit_GFX.cpp#L1055

PS: I discovered this by sprinkling the C++11 `override` on SSD1306 functions in a dev branch. It might be useful to check those override keywords in if we can assume universal C++11 support, but I don't know if that's the case yet.