### PR TITLE
Make it easier to select a screen without having to edit the library

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -70,16 +70,26 @@ All text above, and the splash screen must be included in any redistribution
     SSD1306_96_16
 
     -----------------------------------------------------------------------*/
+#if !defined SSD1306_128_64 && !defined SSD1306_128_32 && !defined SSD1306_96_16
 //   #define SSD1306_128_64
    #define SSD1306_128_32
 //   #define SSD1306_96_16
+#warning Selected SSD1306_128_32 by default.
+#endif
 /*=========================================================================*/
 
 #if defined SSD1306_128_64 && defined SSD1306_128_32
-  #error "Only one SSD1306 display can be specified at once in SSD1306.h"
+ #error "Only one SSD1306 display can be specified at once in SSD1306.h"
 #endif
+#if defined SSD1306_128_64 && defined SSD1306_128_16
+ #error "Only one SSD1306 display can be specified at once in SSD1306.h"
+#endif
+#if defined SSD1306_128_16 && defined SSD1306_128_32
+ #error "Only one SSD1306 display can be specified at once in SSD1306.h"
+#endif
+
 #if !defined SSD1306_128_64 && !defined SSD1306_128_32 && !defined SSD1306_96_16
-  #error "At least one SSD1306 display must be specified in SSD1306.h"
+ #error "At least one SSD1306 display must be specified in SSD1306.h"
 #endif
 
 #if defined SSD1306_128_64


### PR DESCRIPTION
The  Adafruit_SSD1306.h needs to be edited in place to specify a screen other than a 128x32 screen.

In common settings is somewhat cumbersome having to 'edit' a third party library after each update/ during automated CI chains.

This diff retains the 128x32 default; allows for the same changes to still be made the same way to the   Adafruit_SSD1306.h  if so desired. 

But it _also_ allows for the SSD1306_128_64 et.al. define to be set prior to include. Thus moving the configuration fully into `userland'.