### PR TITLE
added scrollUP() to automatically scroll a display when println() is used

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -1099,3 +1099,28 @@ void Adafruit_SSD1306::dim(boolean dim) {
   TRANSACTION_END
 }
 
+
+/**************************************************************************/
+/*!
+   @brief Scroll display up one line, reseting cursor y to print at bottom
+*/
+/**************************************************************************/
+void Adafruit_SSD1306::scrollUp(void) {
+	/*
+	* - supporting oled 128x32 pixel display so know width
+	* -- a row of pixels 128 columns x 8 down is 8 * 16, left to right
+	*/
+	
+	// copy 2nd to last line from buffer to top of scroll buffer; (char pixel width with 8 as base size of 1) * (total pixel width / 8 as that is how this display is addressed) * (lines)
+	int intLineSize = ((textsize * SSD1306_PIXEL_CHUNK) * (WIDTH / SSD1306_PIXEL_CHUNK));
+	memcpy(buffer, buffer + intLineSize, SSD1306_BUFF_SIZE - intLineSize);
+
+	// clear buffer last line; (char pixel width with 8 as base size of 1) * (total pixel width / 8 as that is how this display is addressed) * (font size for height * lines)
+	int intOffsetLastLine = intLineSize * 3;
+	memset(buffer + intOffsetLastLine, 0, SSD1306_BUFF_SIZE - intOffsetLastLine);
+
+	setCursor(cursor_x, (textsize * SSD1306_PIXEL_CHUNK) * 3);
+
+}
+
+

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -102,6 +102,8 @@
 #if defined SSD1306_128_32
  #define SSD1306_LCDWIDTH  128 ///< DEPRECATED: width w/SSD1306_128_32 defined
  #define SSD1306_LCDHEIGHT  32 ///< DEPRECATED: height w/SSD1306_128_32 defined
+ #define SSD1306_PIXEL_CHUNK 8 /// for scrollUP()
+ #define SSD1306_BUFF_SIZE (SSD1306_LCDWIDTH * ((SSD1306_LCDHEIGHT + 7) / 8)) // for scrollUP()
 #endif
 #if defined SSD1306_96_16
  #define SSD1306_LCDWIDTH   96 ///< DEPRECATED: width w/SSD1306_96_16 defined
@@ -148,6 +150,10 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void         ssd1306_command(uint8_t c);
   boolean      getPixel(int16_t x, int16_t y);
   uint8_t     *getBuffer(void);
+
+	// adding function to scroll display up a line; for use with println
+	void				scrollUp(void); 		// scroll display up one line of text
+
 
  private:
   inline void  SPIwrite(uint8_t d) __attribute__((always_inline));


### PR DESCRIPTION
This is my first pull request to a public project ever so hopefully it's fine, otherwise let me know so I can improve. I tried implementing this keeping in mind other products but I am not sure this will be okay. By all means, have a more experienced person change what is required.

This was developed on a Adafruit Huzzah32 Feather stack with an OLED 128x32 Wing using the Adafruit Arduino support libraries on Win10x64 MS Visual Studio 2017 Community Edition with VisualGDB extensions supporting my Segger J-Link for JTAG debugging.

This function is called from Adafruit_GFX (pull coming soon)::write() to scroll the display is cursorY is greater than the display height. It will also call the driver display() function. This function is to allow the print system to display as many other terminals do. Printing without \n will work as expected. I can see adding a flag to toggle this behavior.

- only supporting standard font for ssd1306 OLED 128x32 as that is all I have to test on

Thanks Adafruit for the openness of your systems !

Attached is an Arduino test sketch. Please remember you need my fork of Adafruit_GFX for it to work:
[scroll-print.zip](https://github.com/adafruit/Adafruit_SSD1306/files/2752608/scroll-print.zip)
