### PR TITLE
Namespace issues: #define BLACK conflicts - fixes #146

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -592,7 +592,7 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
     @param  y
             Row of display -- 0 at top to (screen height -1) at bottom.
     @param  color
-            Pixel color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
+            Pixel color, one of: SSD1306_BLACK, _WHITE or _INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -616,9 +616,9 @@ void Adafruit_SSD1306::drawPixel(int16_t x, int16_t y, uint16_t color) {
       break;
     }
     switch(color) {
-     case Adafruit_SSD1306::WHITE:   buffer[x + (y/8)*WIDTH] |=  (1 << (y&7)); break;
-     case Adafruit_SSD1306::BLACK:   buffer[x + (y/8)*WIDTH] &= ~(1 << (y&7)); break;
-     case Adafruit_SSD1306::INVERSE: buffer[x + (y/8)*WIDTH] ^=  (1 << (y&7)); break;
+     case SSD1306_WHITE:   buffer[x + (y/8)*WIDTH] |=  (1 << (y&7)); break;
+     case SSD1306_BLACK:   buffer[x + (y/8)*WIDTH] &= ~(1 << (y&7)); break;
+     case SSD1306_INVERSE: buffer[x + (y/8)*WIDTH] ^=  (1 << (y&7)); break;
     }
   }
 }
@@ -644,7 +644,7 @@ void Adafruit_SSD1306::clearDisplay(void) {
     @param  w
             Width of line, in pixels.
     @param  color
-            Line color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
+            Line color, one of: SSD1306_BLACK, _WHITE or _INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -695,9 +695,9 @@ void Adafruit_SSD1306::drawFastHLineInternal(
       uint8_t *pBuf = &buffer[(y / 8) * WIDTH + x],
                mask = 1 << (y & 7);
       switch(color) {
-       case Adafruit_SSD1306::WHITE:               while(w--) { *pBuf++ |= mask; }; break;
-       case Adafruit_SSD1306::BLACK: mask = ~mask; while(w--) { *pBuf++ &= mask; }; break;
-       case Adafruit_SSD1306::INVERSE:             while(w--) { *pBuf++ ^= mask; }; break;
+       case SSD1306_WHITE:               while(w--) { *pBuf++ |= mask; }; break;
+       case SSD1306_BLACK: mask = ~mask; while(w--) { *pBuf++ &= mask; }; break;
+       case SSD1306_INVERSE:             while(w--) { *pBuf++ ^= mask; }; break;
       }
     }
   }
@@ -713,7 +713,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(
     @param  h
             Height of line, in pixels.
     @param  color
-            Line color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
+            Line color, one of: SSD1306_BLACK, _WHITE or _INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -781,9 +781,9 @@ void Adafruit_SSD1306::drawFastVLineInternal(
         if(h < mod) mask &= (0XFF >> (mod - h));
 
         switch(color) {
-         case Adafruit_SSD1306::WHITE:   *pBuf |=  mask; break;
-         case Adafruit_SSD1306::BLACK:   *pBuf &= ~mask; break;
-         case Adafruit_SSD1306::INVERSE: *pBuf ^=  mask; break;
+         case SSD1306_WHITE:   *pBuf |=  mask; break;
+         case SSD1306_BLACK:   *pBuf &= ~mask; break;
+         case SSD1306_INVERSE: *pBuf ^=  mask; break;
         }
         pBuf += WIDTH;
       }
@@ -792,7 +792,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(
         h -= mod;
         // Write solid bytes while we can - effectively 8 rows at a time
         if(h >= 8) {
-          if(color == Adafruit_SSD1306::INVERSE) {
+          if(color == SSD1306_INVERSE) {
             // separate copy of the code so we don't impact performance of
             // black/white write version with an extra comparison per loop
             do {
@@ -802,7 +802,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             } while(h >= 8);
           } else {
             // store a local value to work with
-            uint8_t val = (color != Adafruit_SSD1306::BLACK) ? 255 : 0;
+            uint8_t val = (color != SSD1306_BLACK) ? 255 : 0;
             do {
               *pBuf = val;    // Set byte
               pBuf += WIDTH;  // Advance pointer 8 rows
@@ -822,9 +822,9 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             { 0x00, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F };
           uint8_t mask = pgm_read_byte(&postmask[mod]);
           switch(color) {
-           case Adafruit_SSD1306::WHITE:   *pBuf |=  mask; break;
-           case Adafruit_SSD1306::BLACK:   *pBuf &= ~mask; break;
-           case Adafruit_SSD1306::INVERSE: *pBuf ^=  mask; break;
+           case SSD1306_WHITE:   *pBuf |=  mask; break;
+           case SSD1306_BLACK:   *pBuf &= ~mask; break;
+           case SSD1306_INVERSE: *pBuf ^=  mask; break;
           }
         }
       }
@@ -838,8 +838,8 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             Column of display -- 0 at left to (screen width - 1) at right.
     @param  y
             Row of display -- 0 at top to (screen height -1) at bottom.
-    @return true if pixel is set (usually Adafruit_SSD1306::WHITE, unless display invert mode
-            is enabled), false if clear (Adafruit_SSD1306::BLACK).
+    @return true if pixel is set (usually SSD1306_WHITE, unless display invert mode
+            is enabled), false if clear (SSD1306_BLACK).
     @note   Reads from buffer contents; may not reflect current contents of
             screen if display() has not been called.
 */
@@ -1066,8 +1066,8 @@ void Adafruit_SSD1306::stopscroll(void) {
     @note   This has an immediate effect on the display, no need to call the
             display() function -- buffer contents are not changed, rather a
             different pixel mode of the display hardware is used. When
-            enabled, drawing Adafruit_SSD1306::BLACK (value 0) pixels will actually draw white,
-            WHITE (value 1) will draw black.
+            enabled, drawing SSD1306_BLACK (value 0) pixels will actually draw white,
+            SSD1306_WHITE (value 1) will draw black.
 */
 void Adafruit_SSD1306::invertDisplay(boolean i) {
   TRANSACTION_START

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -592,7 +592,7 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
     @param  y
             Row of display -- 0 at top to (screen height -1) at bottom.
     @param  color
-            Pixel color, one of: SSD1306_BLACK, _WHITE or _INVERT.
+            Pixel color, one of: SSD1306_BLACK, SSD1306_WHITE or SSD1306_INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -644,7 +644,7 @@ void Adafruit_SSD1306::clearDisplay(void) {
     @param  w
             Width of line, in pixels.
     @param  color
-            Line color, one of: SSD1306_BLACK, _WHITE or _INVERT.
+            Line color, one of: SSD1306_BLACK, SSD1306_WHITE or SSD1306_INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -713,7 +713,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(
     @param  h
             Height of line, in pixels.
     @param  color
-            Line color, one of: SSD1306_BLACK, _WHITE or _INVERT.
+            Line color, one of: SSD1306_BLACK, SSD1306_WHITE or SSD1306_INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -592,7 +592,7 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
     @param  y
             Row of display -- 0 at top to (screen height -1) at bottom.
     @param  color
-            Pixel color, one of: BLACK, WHITE or INVERT.
+            Pixel color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -616,9 +616,9 @@ void Adafruit_SSD1306::drawPixel(int16_t x, int16_t y, uint16_t color) {
       break;
     }
     switch(color) {
-     case WHITE:   buffer[x + (y/8)*WIDTH] |=  (1 << (y&7)); break;
-     case BLACK:   buffer[x + (y/8)*WIDTH] &= ~(1 << (y&7)); break;
-     case INVERSE: buffer[x + (y/8)*WIDTH] ^=  (1 << (y&7)); break;
+     case Adafruit_SSD1306::WHITE:   buffer[x + (y/8)*WIDTH] |=  (1 << (y&7)); break;
+     case Adafruit_SSD1306::BLACK:   buffer[x + (y/8)*WIDTH] &= ~(1 << (y&7)); break;
+     case Adafruit_SSD1306::INVERSE: buffer[x + (y/8)*WIDTH] ^=  (1 << (y&7)); break;
     }
   }
 }
@@ -644,7 +644,7 @@ void Adafruit_SSD1306::clearDisplay(void) {
     @param  w
             Width of line, in pixels.
     @param  color
-            Line color, one of: BLACK, WHITE or INVERT.
+            Line color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -695,9 +695,9 @@ void Adafruit_SSD1306::drawFastHLineInternal(
       uint8_t *pBuf = &buffer[(y / 8) * WIDTH + x],
                mask = 1 << (y & 7);
       switch(color) {
-       case WHITE:               while(w--) { *pBuf++ |= mask; }; break;
-       case BLACK: mask = ~mask; while(w--) { *pBuf++ &= mask; }; break;
-       case INVERSE:             while(w--) { *pBuf++ ^= mask; }; break;
+       case Adafruit_SSD1306::WHITE:               while(w--) { *pBuf++ |= mask; }; break;
+       case Adafruit_SSD1306::BLACK: mask = ~mask; while(w--) { *pBuf++ &= mask; }; break;
+       case Adafruit_SSD1306::INVERSE:             while(w--) { *pBuf++ ^= mask; }; break;
       }
     }
   }
@@ -713,7 +713,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(
     @param  h
             Height of line, in pixels.
     @param  color
-            Line color, one of: BLACK, WHITE or INVERT.
+            Line color, one of: Adafruit_SSD1306::BLACK, WHITE or INVERT.
     @return None (void).
     @note   Changes buffer contents only, no immediate effect on display.
             Follow up with a call to display(), or with other graphics
@@ -781,9 +781,9 @@ void Adafruit_SSD1306::drawFastVLineInternal(
         if(h < mod) mask &= (0XFF >> (mod - h));
 
         switch(color) {
-         case WHITE:   *pBuf |=  mask; break;
-         case BLACK:   *pBuf &= ~mask; break;
-         case INVERSE: *pBuf ^=  mask; break;
+         case Adafruit_SSD1306::WHITE:   *pBuf |=  mask; break;
+         case Adafruit_SSD1306::BLACK:   *pBuf &= ~mask; break;
+         case Adafruit_SSD1306::INVERSE: *pBuf ^=  mask; break;
         }
         pBuf += WIDTH;
       }
@@ -792,7 +792,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(
         h -= mod;
         // Write solid bytes while we can - effectively 8 rows at a time
         if(h >= 8) {
-          if(color == INVERSE) {
+          if(color == Adafruit_SSD1306::INVERSE) {
             // separate copy of the code so we don't impact performance of
             // black/white write version with an extra comparison per loop
             do {
@@ -802,7 +802,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             } while(h >= 8);
           } else {
             // store a local value to work with
-            uint8_t val = (color != BLACK) ? 255 : 0;
+            uint8_t val = (color != Adafruit_SSD1306::BLACK) ? 255 : 0;
             do {
               *pBuf = val;    // Set byte
               pBuf += WIDTH;  // Advance pointer 8 rows
@@ -822,9 +822,9 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             { 0x00, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F };
           uint8_t mask = pgm_read_byte(&postmask[mod]);
           switch(color) {
-           case WHITE:   *pBuf |=  mask; break;
-           case BLACK:   *pBuf &= ~mask; break;
-           case INVERSE: *pBuf ^=  mask; break;
+           case Adafruit_SSD1306::WHITE:   *pBuf |=  mask; break;
+           case Adafruit_SSD1306::BLACK:   *pBuf &= ~mask; break;
+           case Adafruit_SSD1306::INVERSE: *pBuf ^=  mask; break;
           }
         }
       }
@@ -838,8 +838,8 @@ void Adafruit_SSD1306::drawFastVLineInternal(
             Column of display -- 0 at left to (screen width - 1) at right.
     @param  y
             Row of display -- 0 at top to (screen height -1) at bottom.
-    @return true if pixel is set (usually WHITE, unless display invert mode
-            is enabled), false if clear (BLACK).
+    @return true if pixel is set (usually Adafruit_SSD1306::WHITE, unless display invert mode
+            is enabled), false if clear (Adafruit_SSD1306::BLACK).
     @note   Reads from buffer contents; may not reflect current contents of
             screen if display() has not been called.
 */
@@ -1066,7 +1066,7 @@ void Adafruit_SSD1306::stopscroll(void) {
     @note   This has an immediate effect on the display, no need to call the
             display() function -- buffer contents are not changed, rather a
             different pixel mode of the display hardware is used. When
-            enabled, drawing BLACK (value 0) pixels will actually draw white,
+            enabled, drawing Adafruit_SSD1306::BLACK (value 0) pixels will actually draw white,
             WHITE (value 1) will draw black.
 */
 void Adafruit_SSD1306::invertDisplay(boolean i) {

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -54,9 +54,18 @@
   #define HAVE_PORTREG
 #endif
 
-//#define BLACK                          0 ///< Draw 'off' pixels
-//#define WHITE                          1 ///< Draw 'on' pixels
-//#define INVERSE                        2 ///< Invert pixels
+/// The following "raw" color names are kept for backwards client compatability
+/// They can be disabled by predefining this macro before including the Adafruit header
+/// client code will then need to be modified to use the scoped enum values directly
+#ifndef NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY
+#define BLACK                     SSD1306_BLACK    ///< Draw 'off' pixels
+#define WHITE                     SSD1306_WHITE    ///< Draw 'on' pixels
+#define INVERSE                   SSD1306_INVERSE  ///< Invert pixels
+#endif
+        /// fit into the SSD1306_ naming scheme
+#define SSD1306_BLACK               0    ///< Draw 'off' pixels
+#define SSD1306_WHITE               1    ///< Draw 'on' pixels
+#define SSD1306_INVERSE             2    ///< Invert pixels
 
 #define SSD1306_MEMORYMODE          0x20 ///< See datasheet
 #define SSD1306_COLUMNADDR          0x21 ///< See datasheet
@@ -129,8 +138,6 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   Adafruit_SSD1306(int8_t rst_pin = -1);
 
   ~Adafruit_SSD1306(void);
-
-  enum SSD1306_Colors { BLACK=0, WHITE=1, INVERSE=2 };
 
   boolean      begin(uint8_t switchvcc=SSD1306_SWITCHCAPVCC,
                  uint8_t i2caddr=0, boolean reset=true,

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -54,9 +54,9 @@
   #define HAVE_PORTREG
 #endif
 
-#define BLACK                          0 ///< Draw 'off' pixels
-#define WHITE                          1 ///< Draw 'on' pixels
-#define INVERSE                        2 ///< Invert pixels
+//#define BLACK                          0 ///< Draw 'off' pixels
+//#define WHITE                          1 ///< Draw 'on' pixels
+//#define INVERSE                        2 ///< Invert pixels
 
 #define SSD1306_MEMORYMODE          0x20 ///< See datasheet
 #define SSD1306_COLUMNADDR          0x21 ///< See datasheet
@@ -129,6 +129,8 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   Adafruit_SSD1306(int8_t rst_pin = -1);
 
   ~Adafruit_SSD1306(void);
+
+  enum SSD1306_Colors { BLACK=0, WHITE=1, INVERSE=2 };
 
   boolean      begin(uint8_t switchvcc=SSD1306_SWITCHCAPVCC,
                  uint8_t i2caddr=0, boolean reset=true,

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ You will also have to install the **Adafruit GFX library** which provides graphi
 ## Changes
 Pull Request:
    (September 2019) 
-   * Changed #defines for BLACK, WHITE and INVERSE into a class Adafruit_SSD1306 scoped enum to eliminate compiler errors in code that used either those words or defined other values to them. This means that there is a required code change, from (e.g.) WHITE to Adafruit_SSD1306::WHITE:
-     * <code> display.drawPixel(10, 10, WHITE);</code>    // to
-     * <code>display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);</code>
+   * new #defines for SSD1306_BLACK, SSD1306_WHITE and SSD1306_INVERSE that match existing #define naming scheme and won't conflict with common color names
+   * old #defines for BLACK, WHITE and INVERSE kept for backwards compat (opt-out with #define NO_ADAFRUIT_SSD1306_COLOR_COMPATIBILITY)
 
 Version 1.2 (November 2018) introduces some significant changes:
 

--- a/examples/OLED_featherwing/OLED_featherwing.ino
+++ b/examples/OLED_featherwing/OLED_featherwing.ino
@@ -59,7 +59,7 @@ void setup() {
 
   // text display tests
   display.setTextSize(1);
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.setCursor(0,0);
   display.print("Connecting to SSID\n'adafruit':");
   display.print("connected!");

--- a/examples/OLED_featherwing/OLED_featherwing.ino
+++ b/examples/OLED_featherwing/OLED_featherwing.ino
@@ -59,7 +59,7 @@ void setup() {
 
   // text display tests
   display.setTextSize(1);
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.setCursor(0,0);
   display.print("Connecting to SSID\n'adafruit':");
   display.print("connected!");

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -70,7 +70,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
+  display.drawPixel(10, 10, SSD1306_WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -125,12 +125,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, i, display.height()-1, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -184,7 +184,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -197,7 +197,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -209,7 +209,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -222,7 +222,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -235,7 +235,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::WHITE);
+      display.height()/4, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -249,7 +249,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::INVERSE);
+      display.height()/4, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -264,7 +264,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
+      display.width()/2+i, display.height()/2+i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -280,7 +280,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
+      display.width()/2+i, display.height()/2+i, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -292,7 +292,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
+  display.setTextColor(SSD1306_WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -311,15 +311,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
+  display.setTextColor(SSD1306_WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
+  display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -330,7 +330,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -389,7 +389,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, SSD1306_WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -70,7 +70,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, WHITE);
+  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -125,12 +125,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, WHITE);
+    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, WHITE);
+    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, WHITE);
+    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -184,7 +184,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -197,7 +197,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -209,7 +209,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -222,7 +222,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -235,7 +235,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, WHITE);
+      display.height()/4, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -249,7 +249,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, INVERSE);
+      display.height()/4, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -264,7 +264,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, WHITE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -280,7 +280,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, INVERSE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -292,7 +292,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(WHITE); // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -311,15 +311,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(WHITE);        // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(BLACK, WHITE); // Draw 'inverse' text
+  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -330,7 +330,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -389,7 +389,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -83,7 +83,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, WHITE);
+  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -138,12 +138,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, WHITE);
+    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, WHITE);
+    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -152,12 +152,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, WHITE);
+    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -166,12 +166,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -180,12 +180,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -197,7 +197,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -210,7 +210,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -222,7 +222,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -235,7 +235,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -248,7 +248,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, WHITE);
+      display.height()/4, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -262,7 +262,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, INVERSE);
+      display.height()/4, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -277,7 +277,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, WHITE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -293,7 +293,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, INVERSE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -305,7 +305,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(WHITE); // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -324,15 +324,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(WHITE);        // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(BLACK, WHITE); // Draw 'inverse' text
+  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -343,7 +343,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -402,7 +402,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
+++ b/examples/ssd1306_128x32_spi/ssd1306_128x32_spi.ino
@@ -83,7 +83,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
+  display.drawPixel(10, 10, SSD1306_WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -138,12 +138,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, i, display.height()-1, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -152,12 +152,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -166,12 +166,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -180,12 +180,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -197,7 +197,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -210,7 +210,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -222,7 +222,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -235,7 +235,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -248,7 +248,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::WHITE);
+      display.height()/4, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -262,7 +262,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::INVERSE);
+      display.height()/4, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -277,7 +277,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
+      display.width()/2+i, display.height()/2+i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -293,7 +293,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
+      display.width()/2+i, display.height()/2+i, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -305,7 +305,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
+  display.setTextColor(SSD1306_WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -324,15 +324,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
+  display.setTextColor(SSD1306_WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
+  display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -343,7 +343,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -402,7 +402,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, SSD1306_WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -70,7 +70,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
+  display.drawPixel(10, 10, SSD1306_WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -125,12 +125,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, i, display.height()-1, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -184,7 +184,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -197,7 +197,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -209,7 +209,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -222,7 +222,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -235,7 +235,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::WHITE);
+      display.height()/4, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -249,7 +249,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::INVERSE);
+      display.height()/4, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -264,7 +264,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
+      display.width()/2+i, display.height()/2+i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -280,7 +280,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
+      display.width()/2+i, display.height()/2+i, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -292,7 +292,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
+  display.setTextColor(SSD1306_WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -311,15 +311,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
+  display.setTextColor(SSD1306_WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
+  display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -330,7 +330,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -389,7 +389,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, SSD1306_WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -70,7 +70,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, WHITE);
+  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -125,12 +125,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, WHITE);
+    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, WHITE);
+    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, WHITE);
+    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -184,7 +184,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -197,7 +197,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -209,7 +209,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -222,7 +222,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -235,7 +235,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, WHITE);
+      display.height()/4, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -249,7 +249,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, INVERSE);
+      display.height()/4, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -264,7 +264,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, WHITE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -280,7 +280,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, INVERSE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -292,7 +292,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(WHITE); // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -311,15 +311,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(WHITE);        // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(BLACK, WHITE); // Draw 'inverse' text
+  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -330,7 +330,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -389,7 +389,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -84,7 +84,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
+  display.drawPixel(10, 10, SSD1306_WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, i, display.height()-1, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, 0, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -181,12 +181,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -198,7 +198,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -211,7 +211,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -223,7 +223,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -236,7 +236,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, SSD1306_INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -249,7 +249,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::WHITE);
+      display.height()/4, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -263,7 +263,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, Adafruit_SSD1306::INVERSE);
+      display.height()/4, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -278,7 +278,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
+      display.width()/2+i, display.height()/2+i, SSD1306_WHITE);
     display.display();
     delay(1);
   }
@@ -294,7 +294,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
+      display.width()/2+i, display.height()/2+i, SSD1306_INVERSE);
     display.display();
     delay(1);
   }
@@ -306,7 +306,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
+  display.setTextColor(SSD1306_WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -325,15 +325,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
+  display.setTextColor(SSD1306_WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
+  display.setTextColor(SSD1306_BLACK, SSD1306_WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -344,7 +344,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(Adafruit_SSD1306::WHITE);
+  display.setTextColor(SSD1306_WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -403,7 +403,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, SSD1306_WHITE);
     }
 
     display.display(); // Show the display buffer on the screen

--- a/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
+++ b/examples/ssd1306_128x64_spi/ssd1306_128x64_spi.ino
@@ -84,7 +84,7 @@ void setup() {
   display.clearDisplay();
 
   // Draw a single pixel in white
-  display.drawPixel(10, 10, WHITE);
+  display.drawPixel(10, 10, Adafruit_SSD1306::WHITE);
 
   // Show the display buffer on the screen. You MUST call display() after
   // drawing commands to make them visible on screen!
@@ -139,12 +139,12 @@ void testdrawline() {
   display.clearDisplay(); // Clear display buffer
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, WHITE);
+    display.drawLine(0, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn line
     delay(1);
   }
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(0, 0, display.width()-1, i, WHITE);
+    display.drawLine(0, 0, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -153,12 +153,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(0, display.height()-1, i, 0, WHITE);
+    display.drawLine(0, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(0, display.height()-1, display.width()-1, i, WHITE);
+    display.drawLine(0, display.height()-1, display.width()-1, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -167,12 +167,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=display.width()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, i, 0, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, i, 0, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=display.height()-1; i>=0; i-=4) {
-    display.drawLine(display.width()-1, display.height()-1, 0, i, WHITE);
+    display.drawLine(display.width()-1, display.height()-1, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -181,12 +181,12 @@ void testdrawline() {
   display.clearDisplay();
 
   for(i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, WHITE);
+    display.drawLine(display.width()-1, 0, 0, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
   for(i=0; i<display.width(); i+=4) {
-    display.drawLine(display.width()-1, 0, i, display.height()-1, WHITE);
+    display.drawLine(display.width()-1, 0, i, display.height()-1, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -198,7 +198,7 @@ void testdrawrect(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<display.height()/2; i+=2) {
-    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, WHITE);
+    display.drawRect(i, i, display.width()-2*i, display.height()-2*i, Adafruit_SSD1306::WHITE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -211,7 +211,7 @@ void testfillrect(void) {
 
   for(int16_t i=0; i<display.height()/2; i+=3) {
     // The INVERSE color is used so rectangles alternate white/black
-    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, INVERSE);
+    display.fillRect(i, i, display.width()-i*2, display.height()-i*2, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn rectangle
     delay(1);
   }
@@ -223,7 +223,7 @@ void testdrawcircle(void) {
   display.clearDisplay();
 
   for(int16_t i=0; i<max(display.width(),display.height())/2; i+=2) {
-    display.drawCircle(display.width()/2, display.height()/2, i, WHITE);
+    display.drawCircle(display.width()/2, display.height()/2, i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -236,7 +236,7 @@ void testfillcircle(void) {
 
   for(int16_t i=max(display.width(),display.height())/2; i>0; i-=3) {
     // The INVERSE color is used so circles alternate white/black
-    display.fillCircle(display.width() / 2, display.height() / 2, i, INVERSE);
+    display.fillCircle(display.width() / 2, display.height() / 2, i, Adafruit_SSD1306::INVERSE);
     display.display(); // Update screen with each newly-drawn circle
     delay(1);
   }
@@ -249,7 +249,7 @@ void testdrawroundrect(void) {
 
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     display.drawRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, WHITE);
+      display.height()/4, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -263,7 +263,7 @@ void testfillroundrect(void) {
   for(int16_t i=0; i<display.height()/2-2; i+=2) {
     // The INVERSE color is used so round-rects alternate white/black
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i,
-      display.height()/4, INVERSE);
+      display.height()/4, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -278,7 +278,7 @@ void testdrawtriangle(void) {
     display.drawTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, WHITE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::WHITE);
     display.display();
     delay(1);
   }
@@ -294,7 +294,7 @@ void testfilltriangle(void) {
     display.fillTriangle(
       display.width()/2  , display.height()/2-i,
       display.width()/2-i, display.height()/2+i,
-      display.width()/2+i, display.height()/2+i, INVERSE);
+      display.width()/2+i, display.height()/2+i, Adafruit_SSD1306::INVERSE);
     display.display();
     delay(1);
   }
@@ -306,7 +306,7 @@ void testdrawchar(void) {
   display.clearDisplay();
 
   display.setTextSize(1);      // Normal 1:1 pixel scale
-  display.setTextColor(WHITE); // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE); // Draw white text
   display.setCursor(0, 0);     // Start at top-left corner
   display.cp437(true);         // Use full 256 char 'Code Page 437' font
 
@@ -325,15 +325,15 @@ void testdrawstyles(void) {
   display.clearDisplay();
 
   display.setTextSize(1);             // Normal 1:1 pixel scale
-  display.setTextColor(WHITE);        // Draw white text
+  display.setTextColor(Adafruit_SSD1306::WHITE);        // Draw white text
   display.setCursor(0,0);             // Start at top-left corner
   display.println(F("Hello, world!"));
 
-  display.setTextColor(BLACK, WHITE); // Draw 'inverse' text
+  display.setTextColor(Adafruit_SSD1306::BLACK, Adafruit_SSD1306::WHITE); // Draw 'inverse' text
   display.println(3.141592);
 
   display.setTextSize(2);             // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.print(F("0x")); display.println(0xDEADBEEF, HEX);
 
   display.display();
@@ -344,7 +344,7 @@ void testscrolltext(void) {
   display.clearDisplay();
 
   display.setTextSize(2); // Draw 2X-scale text
-  display.setTextColor(WHITE);
+  display.setTextColor(Adafruit_SSD1306::WHITE);
   display.setCursor(10, 0);
   display.println(F("scroll"));
   display.display();      // Show initial text
@@ -403,7 +403,7 @@ void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h) {
 
     // Draw each snowflake:
     for(f=0; f< NUMFLAKES; f++) {
-      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, WHITE);
+      display.drawBitmap(icons[f][XPOS], icons[f][YPOS], bitmap, w, h, Adafruit_SSD1306::WHITE);
     }
 
     display.display(); // Show the display buffer on the screen


### PR DESCRIPTION
Commented out #defines for BLACK, WHITE, INVERSE
Created enum in Adafruit_SSD1306
      enum SSD1306_Colors { BLACK=0, WHITE=1, INVERSE=2 };
Modified implementation to use the enums instead of defines
Updated sketches in examples directory
Tested with several of my existing projects

This is an incompatible change!  
User's sketch code will need to change 
uses of, for example, WHITE change to Adafruit_SSD1306::WHITE

I chose to NOT leave behind compatibility defines of the form
#define BLACK Adafruit_SSD1306::BLACK
since they would still cause the original problem :-)
  -John