### PR TITLE
save correct contrast setting for use in dim() function

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -543,30 +543,26 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
     SSD1306_COMSCANDEC };
   ssd1306_commandList(init3, sizeof(init3));
 
+  uint8_t comPins = 0x02;
+  contrast = 0x8F;
+
   if((WIDTH == 128) && (HEIGHT == 32)) {
-    static const uint8_t PROGMEM init4a[] = {
-      SSD1306_SETCOMPINS,                 // 0xDA
-      0x02,
-      SSD1306_SETCONTRAST,                // 0x81
-      0x8F };
-    ssd1306_commandList(init4a, sizeof(init4a));
+    comPins = 0x02;
+    contrast = 0x8F;
   } else if((WIDTH == 128) && (HEIGHT == 64)) {
-    static const uint8_t PROGMEM init4b[] = {
-      SSD1306_SETCOMPINS,                 // 0xDA
-      0x12,
-      SSD1306_SETCONTRAST };              // 0x81
-    ssd1306_commandList(init4b, sizeof(init4b));
-    ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF);
+    comPins = 0x12;
+    contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF;
   } else if((WIDTH == 96) && (HEIGHT == 16)) {
-    static const uint8_t PROGMEM init4c[] = {
-      SSD1306_SETCOMPINS,                 // 0xDA
-      0x2,    // ada x12
-      SSD1306_SETCONTRAST };              // 0x81
-    ssd1306_commandList(init4c, sizeof(init4c));
-    ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x10 : 0xAF);
+    comPins = 0x2;    // ada x12
+    contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x10 : 0xAF;
   } else {
     // Other screen varieties -- TBD
   }
+
+  ssd1306_command1(SSD1306_SETCOMPINS);
+  ssd1306_command1(comPins);
+  ssd1306_command1(SSD1306_SETCONTRAST);
+  ssd1306_command1(contrast);
 
   ssd1306_command1(SSD1306_SETPRECHARGE); // 0xd9
   ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x22 : 0xF1);
@@ -1087,17 +1083,10 @@ void Adafruit_SSD1306::invertDisplay(boolean i) {
             display() function -- buffer contents are not changed.
 */
 void Adafruit_SSD1306::dim(boolean dim) {
-  uint8_t contrast;
-
-  if(dim) {
-    contrast = 0; // Dimmed display
-  } else {
-    contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF;
-  }
   // the range of contrast to too small to be really useful
   // it is useful to dim the display
   TRANSACTION_START
   ssd1306_command1(SSD1306_SETCONTRAST);
-  ssd1306_command1(contrast);
+  ssd1306_command1(dim ? 0 : contrast);
   TRANSACTION_END
 }

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -117,7 +117,7 @@
  #define SSD1306_LCDHEIGHT  16 ///< DEPRECATED: height w/SSD1306_96_16 defined
 #endif
 
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with
             SSD1306 OLED displays.
 */
@@ -183,6 +183,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   uint32_t     wireClk;    // Wire speed for SSD1306 transfers
   uint32_t     restoreClk; // Wire speed following SSD1306 transfers
 #endif
+  uint8_t      contrast;    // normal contrast setting for this device
 };
 
 #endif // _Adafruit_SSD1306_H_


### PR DESCRIPTION
In begin(), there is code to compute the correct contrast value, based on the configuration of the display. The same code also computes the comPin setting. This code has been factored so that these two values are computed, and contrast saved in an instance variable.

Later, in dim(), the saved computed contrast value is used when un-dimming the display.

Only these two functions were changed, and an additional uint8_t instance variable was added to the class.

Fixes issue #161 
