### PR TITLE
Expose hardware scroll speeds per datasheet

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -934,20 +934,22 @@ void Adafruit_SSD1306::display(void) {
 /*!
     @brief  Activate a right-handed scroll for all or part of the display.
     @param  start
-            First row.
+            First page of 8 pixels (0x00 to 0x03 for 32 row screen or 0x07 for 64 row screen).
     @param  stop
-            Last row.
+            Last page of 8 pixels (inclusive).
+    @param  rate
+            Control scroll speed with SSD1306_SCROLLFRAMERATE_* values
     @return None (void).
 */
 // To scroll the whole display, run: display.startscrollright(0x00, 0x0F)
-void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop) {
+void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop, uint8_t rate) {
   TRANSACTION_START
   static const uint8_t PROGMEM scrollList1a[] = {
     SSD1306_RIGHT_HORIZONTAL_SCROLL,
     0X00 };
   ssd1306_commandList(scrollList1a, sizeof(scrollList1a));
   ssd1306_command1(start);
-  ssd1306_command1(0X00);
+  ssd1306_command1(rate);
   ssd1306_command1(stop);
   static const uint8_t PROGMEM scrollList1b[] = {
     0X00,
@@ -960,20 +962,22 @@ void Adafruit_SSD1306::startscrollright(uint8_t start, uint8_t stop) {
 /*!
     @brief  Activate a left-handed scroll for all or part of the display.
     @param  start
-            First row.
+            First page of 8 pixels.
     @param  stop
-            Last row.
+            Last page of 8 pixels (inclusive).
+    @param  rate
+            Control scroll speed with SSD1306_SCROLLFRAMERATE_* values
     @return None (void).
 */
 // To scroll the whole display, run: display.startscrollleft(0x00, 0x0F)
-void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop) {
+void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop, uint8_t rate) {
   TRANSACTION_START
   static const uint8_t PROGMEM scrollList2a[] = {
     SSD1306_LEFT_HORIZONTAL_SCROLL,
     0X00 };
   ssd1306_commandList(scrollList2a, sizeof(scrollList2a));
   ssd1306_command1(start);
-  ssd1306_command1(0X00);
+  ssd1306_command1(rate);
   ssd1306_command1(stop);
   static const uint8_t PROGMEM scrollList2b[] = {
     0X00,
@@ -986,13 +990,15 @@ void Adafruit_SSD1306::startscrollleft(uint8_t start, uint8_t stop) {
 /*!
     @brief  Activate a diagonal scroll for all or part of the display.
     @param  start
-            First row.
+            First page of 8 pixels.
     @param  stop
-            Last row.
+            Last page of 8 pixels (inclusive).
+    @param  rate
+            Control scroll speed with SSD1306_SCROLLFRAMERATE_* values
     @return None (void).
 */
 // display.startscrolldiagright(0x00, 0x0F)
-void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop) {
+void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop, uint8_t rate) {
   TRANSACTION_START
   static const uint8_t PROGMEM scrollList3a[] = {
     SSD1306_SET_VERTICAL_SCROLL_AREA,
@@ -1004,7 +1010,7 @@ void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop) {
     0X00 };
   ssd1306_commandList(scrollList3b, sizeof(scrollList3b));
   ssd1306_command1(start);
-  ssd1306_command1(0X00);
+  ssd1306_command1(rate);
   ssd1306_command1(stop);
   static const uint8_t PROGMEM scrollList3c[] = {
     0X01,
@@ -1016,13 +1022,15 @@ void Adafruit_SSD1306::startscrolldiagright(uint8_t start, uint8_t stop) {
 /*!
     @brief  Activate alternate diagonal scroll for all or part of the display.
     @param  start
-            First row.
+            First page of 8 pixels.
     @param  stop
-            Last row.
+            Last page of 8 pixels (inclusive).
+    @param  rate
+            Control scroll speed with SSD1306_SCROLLFRAMERATE_* values
     @return None (void).
 */
 // To scroll the whole display, run: display.startscrolldiagleft(0x00, 0x0F)
-void Adafruit_SSD1306::startscrolldiagleft(uint8_t start, uint8_t stop) {
+void Adafruit_SSD1306::startscrolldiagleft(uint8_t start, uint8_t stop, uint8_t rate) {
   TRANSACTION_START
   static const uint8_t PROGMEM scrollList4a[] = {
     SSD1306_SET_VERTICAL_SCROLL_AREA,
@@ -1034,7 +1042,7 @@ void Adafruit_SSD1306::startscrolldiagleft(uint8_t start, uint8_t stop) {
     0X00 };
   ssd1306_commandList(scrollList4b, sizeof(scrollList4b));
   ssd1306_command1(start);
-  ssd1306_command1(0X00);
+  ssd1306_command1(rate);
   ssd1306_command1(stop);
   static const uint8_t PROGMEM scrollList4c[] = {
     0X01,

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -103,6 +103,16 @@
 #define SSD1306_ACTIVATE_SCROLL                      0x2F ///< Start scroll
 #define SSD1306_SET_VERTICAL_SCROLL_AREA             0xA3 ///< Set scroll range
 
+// hardware scroll rates, fastest is once every 2 frames, slowest is once every 256 frames
+#define SSD1306_SCROLLFRAMERATE_5      0x00 ///< See datasheet 000b
+#define SSD1306_SCROLLFRAMERATE_64     0x01 ///< See datasheet 001b
+#define SSD1306_SCROLLFRAMERATE_128    0x02 ///< See datasheet 010b
+#define SSD1306_SCROLLFRAMERATE_256    0x03 ///< See datasheet 011b
+#define SSD1306_SCROLLFRAMERATE_3      0x04 ///< See datasheet 100b
+#define SSD1306_SCROLLFRAMERATE_4      0x05 ///< See datasheet 101b
+#define SSD1306_SCROLLFRAMERATE_25     0x06 ///< See datasheet 110b
+#define SSD1306_SCROLLFRAMERATE_2      0x07 ///< See datasheet 111b
+
 // Deprecated size stuff for backwards compatibility with old sketches
 #if defined SSD1306_128_64
  #define SSD1306_LCDWIDTH  128 ///< DEPRECATED: width w/SSD1306_128_64 defined
@@ -149,10 +159,10 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   void         drawPixel(int16_t x, int16_t y, uint16_t color);
   virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-  void         startscrollright(uint8_t start, uint8_t stop);
-  void         startscrollleft(uint8_t start, uint8_t stop);
-  void         startscrolldiagright(uint8_t start, uint8_t stop);
-  void         startscrolldiagleft(uint8_t start, uint8_t stop);
+  void         startscrollright(uint8_t start, uint8_t stop, uint8_t rate=SSD1306_SCROLLFRAMERATE_5);
+  void         startscrollleft(uint8_t start, uint8_t stop, uint8_t rate=SSD1306_SCROLLFRAMERATE_5);
+  void         startscrolldiagright(uint8_t start, uint8_t stop, uint8_t rate=SSD1306_SCROLLFRAMERATE_5);
+  void         startscrolldiagleft(uint8_t start, uint8_t stop, uint8_t rate=SSD1306_SCROLLFRAMERATE_5);
   void         stopscroll(void);
   void         ssd1306_command(uint8_t c);
   boolean      getPixel(int16_t x, int16_t y);


### PR DESCRIPTION
Added optional rate parameter to the four `startscroll[diag][right|left](...)` functions which exposes
the variable scroll rate options described in the datasheet.  There are eight rates ranging from one pixel every 2 frames (fastest) to one pixel every 256 frames (slowest).  

For backwards compatibility the default rate is maintained at one pixel every 5 frames (parameter value 0x00).

Also updated comments to explain that start/stop parameters count pages of 8 rows, not individual rows.
