### PR TITLE
Allow a sketch to sub-class the SSD1306 object and change SPI settings

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -176,14 +176,16 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
   PortReg     *mosiPort   , *clkPort   , *dcPort   , *csPort;
   PortMask     mosiPinMask,  clkPinMask,  dcPinMask,  csPinMask;
 #endif
-#if defined(SPI_HAS_TRANSACTION)
-  SPISettings  spiSettings;
-#endif
 #if ARDUINO >= 157
   uint32_t     wireClk;    // Wire speed for SSD1306 transfers
   uint32_t     restoreClk; // Wire speed following SSD1306 transfers
 #endif
   uint8_t      contrast;    // normal contrast setting for this device
+#if defined(SPI_HAS_TRANSACTION)
+protected:
+  // Allow sub-class to change
+  SPISettings  spiSettings;
+#endif
 };
 
 #endif // _Adafruit_SSD1306_H_


### PR DESCRIPTION
At least some of the SSD1309 displays can work with this library if SPI_MODE0 is changed to SPI_MODE3.

Instead of allowing the main constructor to do this, we pulled the spiSettings member out to be protected instead of private.  This allows us to create a smple subclass of this code base to run on these displays.  With this I have a version of the ssd1306_128x64_spi sketch that has the subclass code:
```
class Adafruit_SSD1309_SPI : public Adafruit_SSD1306 {
 public:
  Adafruit_SSD1309_SPI(uint8_t w, uint8_t h, SPIClass *spi,
    int8_t dc_pin, int8_t rst_pin, int8_t cs_pin, uint32_t bitrate=8000000UL) :
    Adafruit_SSD1306(w, h, spi, dc_pin, rst_pin, cs_pin, bitrate) {
#ifdef SPI_HAS_TRANSACTION
  spiSettings = SPISettings(bitrate, MSBFIRST, SPI_MODE3);
#endif

    }
};
```
and then I used the hardware version of the constructor:
```
#define OLED_DC     6
#define OLED_CS     7
#define OLED_RESET  8
Adafruit_SSD1309_SPI display(SCREEN_WIDTH, SCREEN_HEIGHT,
  &SPI, OLED_DC, OLED_RESET, OLED_CS);
```
And it now runs on this display

This is to address the issues mentioned in #167 