### PR TITLE
Replace boolean with standard bool

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -457,8 +457,8 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
             proceeding.
     @note   MUST call this function before any drawing or updates!
 */
-boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
-                                boolean periphBegin) {
+bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
+                             bool periphBegin) {
 
   if ((!buffer) && !(buffer = (uint8_t *)malloc(WIDTH * ((HEIGHT + 7) / 8))))
     return false;
@@ -662,7 +662,7 @@ void Adafruit_SSD1306::clearDisplay(void) {
 */
 void Adafruit_SSD1306::drawFastHLine(int16_t x, int16_t y, int16_t w,
                                      uint16_t color) {
-  boolean bSwap = false;
+  bool bSwap = false;
   switch (rotation) {
   case 1:
     // 90 degree rotation, swap x & y for rotation, then invert x
@@ -745,7 +745,7 @@ void Adafruit_SSD1306::drawFastHLineInternal(int16_t x, int16_t y, int16_t w,
 */
 void Adafruit_SSD1306::drawFastVLine(int16_t x, int16_t y, int16_t h,
                                      uint16_t color) {
-  boolean bSwap = false;
+  bool bSwap = false;
   switch (rotation) {
   case 1:
     // 90 degree rotation, swap x & y for rotation,
@@ -882,7 +882,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y,
     @note   Reads from buffer contents; may not reflect current contents of
             screen if display() has not been called.
 */
-boolean Adafruit_SSD1306::getPixel(int16_t x, int16_t y) {
+bool Adafruit_SSD1306::getPixel(int16_t x, int16_t y) {
   if ((x >= 0) && (x < width()) && (y >= 0) && (y < height())) {
     // Pixel is in-bounds. Rotate coordinates if needed.
     switch (getRotation()) {
@@ -1092,7 +1092,7 @@ void Adafruit_SSD1306::stopscroll(void) {
             enabled, drawing SSD1306_BLACK (value 0) pixels will actually draw
    white, SSD1306_WHITE (value 1) will draw black.
 */
-void Adafruit_SSD1306::invertDisplay(boolean i) {
+void Adafruit_SSD1306::invertDisplay(bool i) {
   TRANSACTION_START
   ssd1306_command1(i ? SSD1306_INVERTDISPLAY : SSD1306_NORMALDISPLAY);
   TRANSACTION_END
@@ -1106,7 +1106,7 @@ void Adafruit_SSD1306::invertDisplay(boolean i) {
     @note   This has an immediate effect on the display, no need to call the
             display() function -- buffer contents are not changed.
 */
-void Adafruit_SSD1306::dim(boolean dim) {
+void Adafruit_SSD1306::dim(bool dim) {
   // the range of contrast to too small to be really useful
   // it is useful to dim the display
   TRANSACTION_START

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -142,12 +142,12 @@ public:
 
   ~Adafruit_SSD1306(void);
 
-  boolean begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = 0,
-                boolean reset = true, boolean periphBegin = true);
+  bool begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = 0,
+             bool reset = true, bool periphBegin = true);
   void display(void);
   void clearDisplay(void);
-  void invertDisplay(boolean i);
-  void dim(boolean dim);
+  void invertDisplay(bool i);
+  void dim(bool dim);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
@@ -157,7 +157,7 @@ public:
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void);
   void ssd1306_command(uint8_t c);
-  boolean getPixel(int16_t x, int16_t y);
+  bool getPixel(int16_t x, int16_t y);
   uint8_t *getBuffer(void);
 
 private:


### PR DESCRIPTION
This PR changes everything of type `boolean` to be of type `bool`. The two types are equivalent: the [Arduino AVR core](https://github.com/arduino/ArduinoCore-avr/blob/3055c1efa3c6980c864f661e6c8cc5d5ac773af4/cores/arduino/Arduino.h#L126) just typedefs `boolean` to `bool`, so no downstream code should be affected by this change. According to the [Arduino Reference](https://www.arduino.cc/reference/en/language/variables/data-types/boolean/), the standard `bool` type is preferred to `boolean`; some cores (e.g. [STM32Duino](https://github.com/stm32duino/Arduino_Core_STM32/blob/b12a55485250076e872fa286a925d6b3ae8d3016/cores/arduino/wiring_constants.h#L110)) even deprecate the `boolean` type alias.

This change should not break any code, given that `boolean` is an alias for the standard `bool`. If anything, it will make it the library work more broadly as it will work with Arduino-compatible boards that don't define a `boolean` type.