### PR TITLE
Added support for flipping along the X axis

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -452,13 +452,17 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
             platforms where a nonstandard begin() function is available
             (e.g. a TwoWire interface on non-default pins, as can be done
             on the ESP8266 and perhaps others).
+    @param  flip
+            If true, flips the display by 180 degrees. This allows flexibility
+            for designs that require the display in a reversed position. Calls
+            to drawing functions can be called as normal.
     @return true on successful allocation/init, false otherwise.
             Well-behaved code should check the return value before
             proceeding.
     @note   MUST call this function before any drawing or updates!
 */
 bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
-                             bool periphBegin) {
+                             bool periphBegin, bool flip) {
 
   if ((!buffer) && !(buffer = (uint8_t *)malloc(WIDTH * ((HEIGHT + 7) / 8))))
     return false;
@@ -546,7 +550,16 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
                                           0x00, // 0x0 act like ks0108
                                           SSD1306_SEGREMAP | 0x1,
                                           SSD1306_COMSCANDEC};
-  ssd1306_commandList(init3, sizeof(init3));
+  static const uint8_t PROGMEM init3Flipped[] = {SSD1306_MEMORYMODE, // 0x20
+                                          0x00, // 0x0 act like ks0108
+                                          SSD1306_SEGREMAP,
+                                          SSD1306_COMSCANINC};
+
+  if (flip) {
+    ssd1306_commandList(init3Flipped, sizeof(init3Flipped));
+  } else {
+    ssd1306_commandList(init3, sizeof(init3));
+  }
 
   uint8_t comPins = 0x02;
   contrast = 0x8F;

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -551,9 +551,9 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
                                           SSD1306_SEGREMAP | 0x1,
                                           SSD1306_COMSCANDEC};
   static const uint8_t PROGMEM init3Flipped[] = {SSD1306_MEMORYMODE, // 0x20
-                                          0x00, // 0x0 act like ks0108
-                                          SSD1306_SEGREMAP,
-                                          SSD1306_COMSCANINC};
+                                                 0x00, // 0x0 act like ks0108
+                                                 SSD1306_SEGREMAP,
+                                                 SSD1306_COMSCANINC};
 
   if (flip) {
     ssd1306_commandList(init3Flipped, sizeof(init3Flipped));

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -143,7 +143,7 @@ public:
   ~Adafruit_SSD1306(void);
 
   bool begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = 0,
-             bool reset = true, bool periphBegin = true);
+             bool reset = true, bool periphBegin = true, bool flip = false);
   void display(void);
   void clearDisplay(void);
   void invertDisplay(bool i);


### PR DESCRIPTION
**Background**

There is nothing to support flipping the display upside down, and still showing the characters/drawings correctly.

**Scope**

This PR addresses the issue that there is no support for flipping the display upside-down. There are some instances in hardware design where the orientation of the display needs to be 180 degrees from the default state. In this PR, a new parameter has been added to the `begin()` function that allows controlling the orientation of the display. Inside the `begin()` function, a new set of instructions can be sent to the display module so that the orientation is flipped.

**Limitations**

The only limitation for this change is accessing the variable. By default (and in the example sketches), the call to the `begin()` function is:

```c
display.begin(SSD1306_SWITCHCAPVCC, 0x3C)
```

Now, to flip the display's orientation, the default parameters must be called before the `flip` parameter:

```c
display.begin(SSD1306_SWITCHCAPVCC, 0x3C, true, true, true)
                                                      ^^^ - `flip` parameter
                                          ^^^   ^^^ - current parameters' default values
```

**Results**

The visual result is as follows:

| Without parameter | With `flip` parameter |
| :-- | --: |
| <img src="https://user-images.githubusercontent.com/42772107/90488976-97d3a380-e134-11ea-98ab-e1d1846adfde.jpg" width="200px"/> | <img src="https://user-images.githubusercontent.com/42772107/90489062-b33eae80-e134-11ea-8744-f3b00fc24464.jpg" width="200px"/> |

