### PR TITLE
Add support for Particle MCUs' I2C buffer sizing

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -56,7 +56,9 @@
 
 // SOME DEFINES AND STATIC VARIABLES USED INTERNALLY -----------------------
 
-#if defined(BUFFER_LENGTH)
+#if defined(I2C_BUFFER_LENGTH)
+#define WIRE_MAX I2C_BUFFER_LENGTH ///< Particle or similar Wire lib
+#elif defined(BUFFER_LENGTH)
 #define WIRE_MAX BUFFER_LENGTH ///< AVR or similar Wire lib
 #elif defined(SERIAL_BUFFER_SIZE)
 #define WIRE_MAX (SERIAL_BUFFER_SIZE - 1) ///< Newer Wire uses RingBuffer

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ATSAM21D    |      X     |            |          |
 Intel Curie |      X     |            |          |
 WICED       |      X     |            |          | No hardware SPI - bitbang only
 ATtiny85    |            |      X     |          |
+Particle    |      X     |            |          |
 
   * ATmega328 : Arduino UNO, Adafruit Pro Trinket, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega32u4 : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0, Adafruit Flora, Bluefruit Micro
@@ -54,5 +55,6 @@ ATtiny85    |            |      X     |          |
   * ATSAM3X8E : Arduino Due
   * ATSAM21D : Arduino Zero, M0 Pro, Adafruit Metro Express, Feather M0
   * ATtiny85 : Adafruit Gemma, Arduino Gemma, Adafruit Trinket
+  * Particle: Particle Argon
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
This makes the library compatible with Particle MCUs (or at any rate the Argon I tested it on).

Every vendor seems to have their own special way of sizing their I2C transmit buffers, and the Particle HAL has yet another way and #define that exposes their default size. Annoyingly, their default buffer length (`I2C_BUFFER_LENGH` = 32) is different from their default _serial_ buffer length (`SERIAL_BUFFER_SIZE` = 64), so the `#else` fallback to 32 doesn't pan out.

Suggestions for future work:
- The optimization to use `SERIAL_BUFFER_SIZE` _may_ not be warranted for all MCUs - consider just letting those fall back on 32 maybe?
- This may want to be a runtime-configurable parameter, with the #define-based values as fallbacks, since one can (in theory) create multiple `Wire` objects which may (at least on Particle) have different buffer sizes.

It would awesome if the standard Wire protocol exposed its dang buffer size, but that's for another day...

Test coverage: tested on my Particle Argon with an Adafruit 128x32 OLED Featherwing.