### PR TITLE
Fix for Heltec CubeCell

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -49,7 +49,7 @@ typedef volatile RwReg PortReg;
 typedef uint32_t PortMask;
 #define HAVE_PORTREG
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
-    !defined(ARDUINO_ARCH_MBED)
+    !defined(ARDUINO_ARCH_MBED) && !defined(__ASR6501__)
 typedef volatile uint32_t PortReg;
 typedef uint32_t PortMask;
 #define HAVE_PORTREG


### PR DESCRIPTION
Heltec's CubeCell Arduino-core is (currently) missing the functions used for direct register-manipulation, so do not define HAVE_PORTREG for it for now. This fix can always be removed, if Heltec ever comes around to implementing said functions.