### PR TITLE
Added comments for pins used on different boards

### DIFF
--- a/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
+++ b/examples/ssd1306_128x32_i2c/ssd1306_128x32_i2c.ino
@@ -27,6 +27,10 @@
 #define SCREEN_HEIGHT 32 // OLED display height, in pixels
 
 // Declaration for an SSD1306 display connected to I2C (SDA, SCL pins)
+// The pins for I2C are defined by the Wire-library. 
+// On an arduino UNO:       A4(SDA), A5(SCL)
+// On an arduino MEGA 2560: 20(SDA), 21(SCL)
+// On an arduino LEONARDO:   2(SDA),  3(SCL), ...
 #define OLED_RESET     4 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 


### PR DESCRIPTION
To help users getting started less painful. You find 1000 pics of Arduino UNOs connected at pins A4, A5 to the display but it doesn't work on your MEGA 2560 because there it's the pins 20, 21 that are used for I2C. You don't necessarily know that already at the moment you start with these displays. And you maybe do not search in the Wire-library for the solution.

My first pull request on GitHub. Hope I did it right.
I changed 3 files. (Readme, examples/ssd1306_128x32_i2c and examples/ssd1306_128x64_i2c)
But in this dialog, it shows just 1 file changed.  We'll see.