### PR TITLE
-Added typedef dfunc_t for user display function

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -40,6 +40,8 @@ typedef class HardwareSPI SPIClass;
 #include <SPI.h>
 #include <Wire.h>
 
+typedef void (* dfunc_t)(void);
+
 #if defined(__AVR__)
 typedef volatile uint8_t PortReg;
 typedef uint8_t PortMask;
@@ -145,6 +147,7 @@ public:
   bool begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = 0,
              bool reset = true, bool periphBegin = true);
   void display(void);
+  void display_d(dfunc_t dfunc);
   void clearDisplay(void);
   void invertDisplay(bool i);
   void dim(bool dim);
@@ -160,7 +163,7 @@ public:
   bool getPixel(int16_t x, int16_t y);
   uint8_t *getBuffer(void);
 
-private:
+protected:
   inline void SPIwrite(uint8_t d) __attribute__((always_inline));
   void drawFastHLineInternal(int16_t x, int16_t y, int16_t w, uint16_t color);
   void drawFastVLineInternal(int16_t x, int16_t y, int16_t h, uint16_t color);


### PR DESCRIPTION
Hello,

This pull request has 2 changes.

- Added new public method display_d(dfunc_t dfunc):

I was finding that on an Arduino Nano the update rate to a 128 x 64 OLED display was taking about 32ms. I needed to poll a position sensor at least every 7ms to not miss counts and wrap around. I added a new display method which calls a users void function every row update. This allowed me to not miss counts any more. I think others might need something like this when critical code needs to get run during a long display update. I opted to create a new method to not impact others working code in any way. I have included a before and after scope shot where a debug pin set high then low on entry and exit to the function.

- private to protected:

I was also frustrated when developing this code by the private settings of the class and would like to suggest the private data be protected to allow for easier experimentation.

My project is currently in a test branch called protected which goes along with this fork and branch called protected

https://github.com/bmoniey/FilamentMeasuringTool/blob/protected/fmt20/fmt20.ino

and

https://github.com/bmoniey/Adafruit_SSD1306/tree/protected

Thanks,

Brian

![SDS00027_after_display_d](https://user-images.githubusercontent.com/24758336/135704546-df753858-04e1-4d46-8b14-adab7b9cf3cd.png)
![SDS00025_before_display_d](https://user-images.githubusercontent.com/24758336/135704551-4b66d444-ee7e-4334-97c9-532d8e812579.png)

