### PR TITLE
Allow for quick updates to screen

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -451,6 +451,19 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t c) {
   TRANSACTION_END
 }
 
+// Send one data byte directly to the display, bypassing the library.
+// This allows for quick localized updates to the screen.
+/*
+	@brief  Write a single byte directly onto the SSD1306
+            display, bypassing the library.
+	@return None (void).
+*/
+void Adafruit_SSD1306::ssd1306_sendData(uint8_t d) {
+    wire->beginTransmission(i2caddr);	// begin I2C transmission   
+    WIRE_WRITE(0x40);					// data mode
+    WIRE_WRITE(d);						// send data
+    wire->endTransmission();			// stop I2C transmission
+}
 // ALLOCATE & INIT DISPLAY -------------------------------------------------
 
 /*!

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -157,6 +157,7 @@ public:
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void);
   void ssd1306_command(uint8_t c);
+  void ssd1306_sendData(uint8_t d);
   bool getPixel(int16_t x, int16_t y);
   uint8_t *getBuffer(void);
 


### PR DESCRIPTION
Changing a small portion of the screen can take a long time as the whole buffer needs to be resent to the display.  This new method allows for quick local updates. In concert with ssd1306_command() which one can use to set the row and column registers, one can quickly write anywhere onto the screen.

