### PR TITLE
Add a no splash #def

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -32,6 +32,9 @@
 // (NEW CODE SHOULD IGNORE THIS, USE THE CONSTRUCTORS THAT ACCEPT WIDTH
 // AND HEIGHT ARGUMENTS).
 
+// Uncomment to disable Adafruit splash logo
+//#define SSD1306_NO_SPLASH
+
 #if defined(ARDUINO_STM32_FEATHER)
 typedef class HardwareSPI SPIClass;
 #endif


### PR DESCRIPTION
This PR adds a commented out #def that can be used to disable the splash logo. I think that'll be an easier thing to point to for cases like this:
https://forums.adafruit.com/viewtopic.php?f=25&t=187139

Still requires editing library source code though. If there's an easier way, then ignore PR.