### PR TITLE
add displayRegional method

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -1130,8 +1130,14 @@ void Adafruit_SSD1306::displayRegional(int16_t x, int16_t y, int16_t w, int16_t 
     wire->endTransmission();
   } else { // SPI
     SSD1306_MODE_DATA
-    while (count--)
+    while (count--){
       SPIwrite(*ptr++);
+      columnCount++;
+      if (columnCount >= w){
+        columnCount = 0;
+        ptr += (width()-w);
+      }
+    }
   }
   TRANSACTION_END
 #if defined(ESP8266)

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -148,6 +148,7 @@ public:
   bool begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = 0,
              bool reset = true, bool periphBegin = true);
   void display(void);
+  void displayRegional(int16_t x, int16_t y, int16_t w, int16_t h);
   void clearDisplay(void);
   void invertDisplay(bool i);
   void dim(bool dim);


### PR DESCRIPTION
update region instead of full screen to save time. In my test, this improvement saves 95% communication time to update a parameter on a 128x64 display, and solves the audio glitch issue.

Tested on 128x64 I2C display, SPI not tested but should work.