### PR TITLE
Screen variety 72*40 added

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -581,7 +581,7 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
       SSD1306_MEMORYMODE, // 0x20
       0x00,               // 0x0 act like ks0108, Horizontal addressing mode
       SSD1306_SEGREMAP | 0x1, SSD1306_COMSCANDEC};
-   ssd1306_commandList(init3, sizeof(init3));
+  ssd1306_commandList(init3, sizeof(init3));
 
   // display parameter default values
   uint8_t comPins = 0x02;
@@ -1002,7 +1002,7 @@ void Adafruit_SSD1306::display(void) {
       SSD1306_PAGEADDR,
       0,    // Page start address
       0xFF, // Page end (not really, but works here)
-      SSD1306_COLUMNADDR};  
+      SSD1306_COLUMNADDR};
   ssd1306_commandList(dlist1, sizeof(dlist1));
   ssd1306_command1(page_start); // Column start address
   ssd1306_command1(page_end);   // Column end address

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -577,17 +577,17 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
 
   ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x10 : 0x14);
 
-  static const uint8_t PROGMEM init3[] = {SSD1306_MEMORYMODE, // 0x20
-                                          0x00, // 0x0 act like ks0108, Horizontal addressing mode
-                                          SSD1306_SEGREMAP | 0x1,
-                                          SSD1306_COMSCANDEC};
-  ssd1306_commandList(init3, sizeof(init3));
+  static const uint8_t PROGMEM init3[] = {
+      SSD1306_MEMORYMODE, // 0x20
+      0x00,               // 0x0 act like ks0108, Horizontal addressing mode
+      SSD1306_SEGREMAP | 0x1, SSD1306_COMSCANDEC};
+   ssd1306_commandList(init3, sizeof(init3));
 
   // display parameter default values
   uint8_t comPins = 0x02;
   contrast = 0x8F;
   page_start = 0;
-  page_end = WIDTH-1;
+  page_end = WIDTH - 1;
 
   if ((WIDTH == 128) && (HEIGHT == 32)) {
     // default
@@ -1000,8 +1000,8 @@ void Adafruit_SSD1306::display(void) {
   TRANSACTION_START
   static const uint8_t PROGMEM dlist1[] = {
       SSD1306_PAGEADDR,
-      0,                      // Page start address
-      0xFF,                   // Page end (not really, but works here)
+      0,    // Page start address
+      0xFF, // Page end (not really, but works here)
       SSD1306_COLUMNADDR};  
   ssd1306_commandList(dlist1, sizeof(dlist1));
   ssd1306_command1(page_start); // Column start address

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -578,20 +578,27 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
   ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x10 : 0x14);
 
   static const uint8_t PROGMEM init3[] = {SSD1306_MEMORYMODE, // 0x20
-                                          0x00, // 0x0 act like ks0108
+                                          0x00, // 0x0 act like ks0108, Horizontal addressing mode
                                           SSD1306_SEGREMAP | 0x1,
                                           SSD1306_COMSCANDEC};
   ssd1306_commandList(init3, sizeof(init3));
 
+  // display parameter default values
   uint8_t comPins = 0x02;
   contrast = 0x8F;
+  page_start = 0;
+  page_end = WIDTH-1;
 
   if ((WIDTH == 128) && (HEIGHT == 32)) {
-    comPins = 0x02;
-    contrast = 0x8F;
+    // default
   } else if ((WIDTH == 128) && (HEIGHT == 64)) {
     comPins = 0x12;
     contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF;
+  } else if ((WIDTH == 72) && (HEIGHT == 40)) {
+    comPins = 0x12;
+    contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x82 : 0xA0;
+    page_start = 28;
+    page_end = 28 + WIDTH - 1;
   } else if ((WIDTH == 96) && (HEIGHT == 16)) {
     comPins = 0x2; // ada x12
     contrast = (vccstate == SSD1306_EXTERNALVCC) ? 0x10 : 0xAF;
@@ -995,9 +1002,10 @@ void Adafruit_SSD1306::display(void) {
       SSD1306_PAGEADDR,
       0,                      // Page start address
       0xFF,                   // Page end (not really, but works here)
-      SSD1306_COLUMNADDR, 0}; // Column start address
+      SSD1306_COLUMNADDR,
+      page_start, // Column start address
+      page_end};  // Column end address
   ssd1306_commandList(dlist1, sizeof(dlist1));
-  ssd1306_command1(WIDTH - 1); // Column end address
 
 #if defined(ESP8266)
   // ESP8266 needs a periodic yield() call to avoid watchdog reset.

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -1002,10 +1002,10 @@ void Adafruit_SSD1306::display(void) {
       SSD1306_PAGEADDR,
       0,                      // Page start address
       0xFF,                   // Page end (not really, but works here)
-      SSD1306_COLUMNADDR,
-      page_start, // Column start address
-      page_end};  // Column end address
+      SSD1306_COLUMNADDR};  
   ssd1306_commandList(dlist1, sizeof(dlist1));
+  ssd1306_command1(page_start); // Column start address
+  ssd1306_command1(page_end);   // Column end address
 
 #if defined(ESP8266)
   // ESP8266 needs a periodic yield() call to avoid watchdog reset.

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -33,7 +33,7 @@
 // AND HEIGHT ARGUMENTS).
 
 // Uncomment to disable Adafruit splash logo
-#define SSD1306_NO_SPLASH
+// #define SSD1306_NO_SPLASH
 
 #if defined(ARDUINO_STM32_FEATHER)
 typedef class HardwareSPI SPIClass;

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -184,8 +184,8 @@ protected:
                       ///< construction.
   int8_t clkPin;      ///< (Clock Pin) set when using SPI set during construction.
   int8_t dcPin;       ///< (Data Pin) set when using SPI set during construction.
-  int8_t csPin;
-      ///< (Chip Select Pin) set when using SPI set during construction.
+  int8_t
+      csPin; ///< (Chip Select Pin) set when using SPI set during construction.
   int8_t rstPin; ///< Display reset pin assignment. Set during construction.
 
 #ifdef HAVE_PORTREG

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -33,7 +33,7 @@
 // AND HEIGHT ARGUMENTS).
 
 // Uncomment to disable Adafruit splash logo
-//#define SSD1306_NO_SPLASH
+#define SSD1306_NO_SPLASH
 
 #if defined(ARDUINO_STM32_FEATHER)
 typedef class HardwareSPI SPIClass;
@@ -178,13 +178,13 @@ protected:
                    ///< begin method is called.
   int8_t i2caddr;  ///< I2C address initialized when begin method is called.
   int8_t vccstate; ///< VCC selection, set by begin method.
-  int8_t page_end; ///< not used
+  uint8_t page_start; ///< display page start
+  uint8_t page_end;   ///< display page end
   int8_t mosiPin;  ///< (Master Out Slave In) set when using SPI set during
                    ///< construction.
   int8_t clkPin;   ///< (Clock Pin) set when using SPI set during construction.
   int8_t dcPin;    ///< (Data Pin) set when using SPI set during construction.
-  int8_t
-      csPin; ///< (Chip Select Pin) set when using SPI set during construction.
+  int8_t csPin;    ///< (Chip Select Pin) set when using SPI set during construction.
   int8_t rstPin; ///< Display reset pin assignment. Set during construction.
 
 #ifdef HAVE_PORTREG

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -182,8 +182,8 @@ protected:
   uint8_t page_end;   ///< display page end
   int8_t mosiPin;     ///< (Master Out Slave In) set when using SPI set during
                       ///< construction.
-  int8_t clkPin;      ///< (Clock Pin) set when using SPI set during construction.
-  int8_t dcPin;       ///< (Data Pin) set when using SPI set during construction.
+  int8_t clkPin; ///< (Clock Pin) set when using SPI set during construction.
+  int8_t dcPin;  ///< (Data Pin) set when using SPI set during construction.
   int8_t
       csPin; ///< (Chip Select Pin) set when using SPI set during construction.
   int8_t rstPin; ///< Display reset pin assignment. Set during construction.

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -170,21 +170,22 @@ protected:
   void ssd1306_command1(uint8_t c);
   void ssd1306_commandList(const uint8_t *c, uint8_t n);
 
-  SPIClass *spi;   ///< Initialized during construction when using SPI. See
-                   ///< SPI.cpp, SPI.h
-  TwoWire *wire;   ///< Initialized during construction when using I2C. See
-                   ///< Wire.cpp, Wire.h
-  uint8_t *buffer; ///< Buffer data used for display buffer. Allocated when
-                   ///< begin method is called.
-  int8_t i2caddr;  ///< I2C address initialized when begin method is called.
-  int8_t vccstate; ///< VCC selection, set by begin method.
+  SPIClass *spi;      ///< Initialized during construction when using SPI. See
+                      ///< SPI.cpp, SPI.h
+  TwoWire *wire;      ///< Initialized during construction when using I2C. See
+                      ///< Wire.cpp, Wire.h
+  uint8_t *buffer;    ///< Buffer data used for display buffer. Allocated when
+                      ///< begin method is called.
+  int8_t i2caddr;     ///< I2C address initialized when begin method is called.
+  int8_t vccstate;    ///< VCC selection, set by begin method.
   uint8_t page_start; ///< display page start
   uint8_t page_end;   ///< display page end
-  int8_t mosiPin;  ///< (Master Out Slave In) set when using SPI set during
-                   ///< construction.
-  int8_t clkPin;   ///< (Clock Pin) set when using SPI set during construction.
-  int8_t dcPin;    ///< (Data Pin) set when using SPI set during construction.
-  int8_t csPin;    ///< (Chip Select Pin) set when using SPI set during construction.
+  int8_t mosiPin;     ///< (Master Out Slave In) set when using SPI set during
+                      ///< construction.
+  int8_t clkPin;      ///< (Clock Pin) set when using SPI set during construction.
+  int8_t dcPin;       ///< (Data Pin) set when using SPI set during construction.
+  int8_t csPin;
+      ///< (Chip Select Pin) set when using SPI set during construction.
   int8_t rstPin; ///< Display reset pin assignment. Set during construction.
 
 #ifdef HAVE_PORTREG

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -33,7 +33,7 @@
 // AND HEIGHT ARGUMENTS).
 
 // Uncomment to disable Adafruit splash logo
-// #define SSD1306_NO_SPLASH
+//  #define SSD1306_NO_SPLASH
 
 #if defined(ARDUINO_STM32_FEATHER)
 typedef class HardwareSPI SPIClass;


### PR DESCRIPTION
The SSD1606 supports a display size of 72*40 pixel that can be found on some micro ESP32-C3 boards
and as standalone displays.
Now the library initializes this variant and applies the column shift as defined in the manuals.

No interface changed.