### PR TITLE
bug: ARDUINO_ARCH_RP2040 does not include the right pgmspace header

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -38,7 +38,10 @@
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
-#elif defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#elif defined(ARDUINO_ARDUINO_NANO33BLE) ||                                    \
+    defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#include <api/deprecated-avr-comp/avr/pgmspace.h>
+#elif defined(ESP8266) || defined(ESP32)
 #include <pgmspace.h>
 #else
 #define pgm_read_byte(addr)                                                    \


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

When utilizing this in a project with the RP2040, the following error occurs

```
fatal error: pgmspace.h: No such file or directory
#include <pgmspace.h>
          ^~~~~~~~~~~~
compilation terminated.
```

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

None known.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Verified by running this locally on a rp2040. Examples on the esp32 still work as expected.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
