### PR TITLE
add ARDUINO_ARCH_RTTHREAD to support RT-Thread

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -36,7 +36,7 @@
  *
  */
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ARDUINO_ARCH_RTTHREAD)
 #include <avr/pgmspace.h>
 #elif defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
 #include <pgmspace.h>

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -51,6 +51,8 @@ typedef uint8_t PortMask;
 typedef volatile RwReg PortReg;
 typedef uint32_t PortMask;
 #define HAVE_PORTREG
+#elif defined(ARDUINO_ARCH_RTTHREAD)
+#undef HAVE_PORTREG
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040)
 typedef volatile uint32_t PortReg;

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Intel Curie |      X     |            |          |
 WICED       |      X     |            |          | No hardware SPI - bitbang only
 ATtiny85    |            |      X     |          |
 Particle    |      X     |            |          |
+RTduino     |      X     |            |          |
 
   * ATmega328 : Arduino UNO, Adafruit Pro Trinket, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega32u4 : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0, Adafruit Flora, Bluefruit Micro
@@ -60,5 +61,6 @@ Particle    |      X     |            |          |
   * ATSAMD21 : Arduino Zero, M0 Pro, Adafruit Metro Express, Feather M0
   * ATtiny85 : Adafruit Gemma, Arduino Gemma, Adafruit Trinket
   * Particle: Particle Argon
+  * RTduino : [RTduino](https://github.com/RTduino/RTduino) is the Arduino ecosystem compatibility layer for [RT-Thread RTOS](https://github.com/RT-Thread/rt-thread) BSPs
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
add ARDUINO_ARCH_RTTHREAD to support RT-Thread/RTduino

RT-Thread is a opensource RTOS, and now RT-Thread software packages has fully support most of the Adafruit Arduino libraries, so that Adafruit Arduino libraries can directly run on RT-Thread BSPs: https://packages.rt-thread.org/en/search.html?search=adafruit

https://github.com/RT-Thread/rt-thread
https://github.com/RTduino/RTduino

![5f6ba774624ce34288008aa1053bc41](https://github.com/adafruit/Adafruit_SSD1306/assets/34888354/4da24cb5-e8f5-41e4-8d01-464897adf649)

![90bac5cfd5c25597b67a18916e301e3](https://github.com/adafruit/Adafruit_SSD1306/assets/34888354/a61f1f58-86d5-4cc0-8887-e1a1754eed3b)


