### PR TITLE
Fix example for RP2040 Feather

### DIFF
--- a/examples/OLED_featherwing/OLED_featherwing.ino
+++ b/examples/OLED_featherwing/OLED_featherwing.ino
@@ -39,7 +39,7 @@
   #define BUTTON_A  9
   #define BUTTON_B  8
   #define BUTTON_C  7
-  #define WIRE Wire1
+  #define WIRE Wire
 #else // 32u4, M0, M4, nrf52840 and 328p
   #define BUTTON_A  9
   #define BUTTON_B  6


### PR DESCRIPTION
While going through guide feedback, it was mentioned that the OLED example was not working for Feather RP2040 and changing it from WIRE1 to WIRE would fix it. I have tested it with both and the change does indeed fix it.

cc @ladyada 