### PR TITLE
Add compatibility with Silicon Labs Arduino boards

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -55,7 +55,7 @@ typedef uint32_t PortMask;
 #undef HAVE_PORTREG
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040) &&            \
-    !defined(ARDUINO_ARCH_SILABS)
+    !defined(ARDUINO_SILABS)
 typedef volatile uint32_t PortReg;
 typedef uint32_t PortMask;
 #define HAVE_PORTREG


### PR DESCRIPTION
Hey!
I added compatibility with Silicon Labs Arduino boards (https://github.com/SiliconLabs/arduino).

**Limitations**: none
**Tests**: tested on 2 different Silicon Labs boards with ssd1306 i2c oled display (more details here: https://github.com/SiliconLabs/arduino/issues/97)

All the best from Arduino team!

cc @silabs-bozont