### PR TITLE
Add compatibilty with CH32V203 devices

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -49,7 +49,8 @@
 #endif
 
 #if !defined(__ARM_ARCH) && !defined(ENERGIA) && !defined(ESP8266) &&          \
-    !defined(ESP32) && !defined(__arc__) && !defined(__RL78__)
+    !defined(ESP32) && !defined(__arc__) && !defined(__RL78__) &&              \
+    !defined(CH32V20x)
 #include <util/delay.h>
 #endif
 

--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -941,7 +941,7 @@ void Adafruit_SSD1306::drawFastVLineInternal(int16_t x, int16_t __y,
         }
       }
     } // endif positive height
-  }   // endif x in bounds
+  } // endif x in bounds
 }
 
 /*!

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -25,15 +25,15 @@
 #define _Adafruit_SSD1306_H_
 
 // ONE of the following three lines must be #defined:
-//#define SSD1306_128_64 ///< DEPRECTAED: old way to specify 128x64 screen
+// #define SSD1306_128_64 ///< DEPRECTAED: old way to specify 128x64 screen
 #define SSD1306_128_32 ///< DEPRECATED: old way to specify 128x32 screen
-//#define SSD1306_96_16  ///< DEPRECATED: old way to specify 96x16 screen
+// #define SSD1306_96_16  ///< DEPRECATED: old way to specify 96x16 screen
 // This establishes the screen dimensions in old Adafruit_SSD1306 sketches
 // (NEW CODE SHOULD IGNORE THIS, USE THE CONSTRUCTORS THAT ACCEPT WIDTH
 // AND HEIGHT ARGUMENTS).
 
 // Uncomment to disable Adafruit splash logo
-//#define SSD1306_NO_SPLASH
+// #define SSD1306_NO_SPLASH
 
 #if defined(ARDUINO_STM32_FEATHER)
 typedef class HardwareSPI SPIClass;

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ WICED       |      X     |            |          | No hardware SPI - bitbang onl
 ATtiny85    |            |      X     |          |
 Particle    |      X     |            |          |
 RTduino     |      X     |            |          |
+CH32 RISC-V |      X     |            |          | 
 
   * ATmega328 : Arduino UNO, Adafruit Pro Trinket, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega32u4 : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0, Adafruit Flora, Bluefruit Micro
@@ -62,5 +63,6 @@ RTduino     |      X     |            |          |
   * ATtiny85 : Adafruit Gemma, Arduino Gemma, Adafruit Trinket
   * Particle: Particle Argon
   * RTduino : [RTduino](https://github.com/RTduino/RTduino) is the Arduino ecosystem compatibility layer for [RT-Thread RTOS](https://github.com/RT-Thread/rt-thread) BSPs
+  * CH32 RISC-V: CH32V203
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
* Board: CH32V203C8T6
* PlatformIO Core version:  6.1.18
* framework: Arduino

Scope: set up modifications on repository in order to make it compatible for CH32V023 devices

Changes on code:

* Added CH32V20X macro (line 53 on Adafruit_SSD1306.cpp);
* Added compatibility with CH32 RISC-V mcu family (line 55 on README.md);
* Added compatibility with CH32V203 device (line 66 on README.md)
