### PR TITLE
Compatibility with RP2350 when using RISC-V cores.

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -50,7 +50,7 @@
 
 #if !defined(__ARM_ARCH) && !defined(ENERGIA) && !defined(ESP8266) &&          \
     !defined(ESP32) && !defined(__arc__) && !defined(__RL78__) &&              \
-    !defined(CH32V20x)
+    !defined(CH32V20x) && !defined(PICO_RISCV)
 #include <util/delay.h>
 #endif
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ WICED       |      X     |            |          | No hardware SPI - bitbang onl
 ATtiny85    |            |      X     |          |
 Particle    |      X     |            |          |
 RTduino     |      X     |            |          |
-CH32 RISC-V |      X     |            |          | 
+CH32 RISC-V |      X     |            |          |
+RP2040      |      X     |            |          |
+RP2350      |      X     |            |          | ARM or RISC-V architecture 
 
   * ATmega328 : Arduino UNO, Adafruit Pro Trinket, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega32u4 : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0, Adafruit Flora, Bluefruit Micro
@@ -64,5 +66,6 @@ CH32 RISC-V |      X     |            |          |
   * Particle: Particle Argon
   * RTduino : [RTduino](https://github.com/RTduino/RTduino) is the Arduino ecosystem compatibility layer for [RT-Thread RTOS](https://github.com/RT-Thread/rt-thread) BSPs
   * CH32 RISC-V: CH32V203
+  * RP2040, RP2350: Tested on Raspberry Pi Pico W/2W with [Arduino-Pico](https://github.com/earlephilhower/arduino-pico) core.
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
Library worked OK on RP2040 (Raspberry Pi Pico W) and RP2350 (Raspberry Pi Pico 2W) when using the ARM cores.
When using the RP2350 RISC-V cores, the compiler gave the following error:
```
sketchbook/libraries/Adafruit_SSD1306/Adafruit_SSD1306.cpp:54:10: fatal error: util/delay.h: No such file or directory
   54 | #include <util/delay.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
exit status 1
Error compiling for board Raspberry Pi Pico 2W.
```
Tested with Arduino 1.8.19 and the [Arduino-Pico core](https://github.com/earlephilhower/arduino-pico) 4.5.4.