### PR TITLE
fix: support Arduino UNO Q

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -53,6 +53,8 @@ typedef uint32_t PortMask;
 #define HAVE_PORTREG
 #elif defined(ARDUINO_ARCH_RTTHREAD)
 #undef HAVE_PORTREG
+#elif defined(ARDUINO_ARCH_ZEPHYR)
+#undef HAVE_PORTREG
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040)
 typedef volatile uint32_t PortReg;


### PR DESCRIPTION
## Description

This pull request fixes the compilation issue reported in #301 by adding support for the **Zephyr RTOS** architecture (`ARDUINO_ARCH_ZEPHYR`).

The change adds two lines to properly undefine `HAVE_PORTREG` for Zephyr-based boards, following the same pattern already used for `ARDUINO_ARCH_RTTHREAD`. This prevents compilation errors when building the library on Zephyr RTOS platforms.

**Files modified:**
- `Adafruit_SSD1306.h`

## Known Limitations

- This fix is specific to **Zephyr RTOS** architecture (`ARDUINO_ARCH_ZEPHYR`).
- No impact on existing supported platforms (AVR, ESP32, ESP8266, STM32, RP2040, MBED, etc.).
- The change is consistent with the existing RTTHREAD handling and does not modify any runtime logic.

## Testing

Verified compilation succeeds on Zephyr RTOS target after this change. The undefined `HAVE_PORTREG` macro error (as described in issue #301) is now resolved.
```
## Testing Result:
<img width="1133" height="727" alt="image" src="https://github.com/user-attachments/assets/dddb6b32-63b8-456b-8718-5b3da9c3751e" />
<img width="1873" height="550" alt="image" src="https://github.com/user-attachments/assets/0a4af209-a7f6-4d9a-8c60-f107269a8291" />
