### PR TITLE
Add Wire.setWireTimeout to avoid I2C bus hangs (closes #288)

### DIFF
--- a/Adafruit_SSD1306.cpp
+++ b/Adafruit_SSD1306.cpp
@@ -522,8 +522,19 @@ bool Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, bool reset,
     // function if it has unusual circumstances (e.g. TWI variants that
     // can accept different SDA/SCL pins, or if two SSD1306 instances
     // with different addresses -- only a single begin() is needed).
-    if (periphBegin)
+    if (periphBegin) {
       wire->begin();
+#ifdef WIRE_HAS_TIMEOUT
+      // Avoid indefinite hangs in the Wire library when the I2C bus stops
+      // responding (e.g. SDA/SCL noise or the display disconnects). The
+      // setWireTimeout() API is exposed by Arduino cores that define
+      // WIRE_HAS_TIMEOUT (Arduino AVR core >= 1.8.6, see ArduinoCore-avr#42).
+      // We only set the timeout when we owned the begin() call -- if the
+      // caller managed Wire themselves, leave their configuration untouched.
+      // See Adafruit_SSD1306 issue #288.
+      wire->setWireTimeout(25000 /* us */, true /* reset on timeout */);
+#endif
+    }
   } else { // Using one of the SPI modes, either soft or hardware
     pinMode(dcPin, OUTPUT); // Set data/command pin as output
     pinMode(csPin, OUTPUT); // Same for chip select


### PR DESCRIPTION
Closes #288.

### Scope of the change

`Adafruit_SSD1306::begin()` (I2C path) now follows the `wire->begin()` call with `wire->setWireTimeout(25000, true)` when the compiler can see that the Wire library exposes the timeout API (`WIRE_HAS_TIMEOUT` defined).

That's the only change — three lines of code plus a short comment, all behind a `#ifdef WIRE_HAS_TIMEOUT` guard.

### Why

The Arduino AVR Wire library historically had no timeout: a noisy or disconnected I2C bus would put `TWI` into an indefinite loop and lock the entire sketch. This was tracked in [ArduinoCore-avr#42](https://github.com/arduino/ArduinoCore-avr/issues/42) and fixed by [ArduinoCore-avr@deea929](https://github.com/arduino/ArduinoCore-avr/commit/deea9293201dbab724b6b0519c35ddba3e6b92d9), which added `setWireTimeout(uint32_t us, bool reset_with_timeout)` and the `WIRE_HAS_TIMEOUT` feature macro.

The Adafruit_SSD1306 library never adopted the new API, so users on AVR cores still get hangs on SDA/SCL noise or display disconnect. Issue #288 asked for that.

### Limitations

- Only the I2C `begin()` path is touched. SPI is unchanged.
- The timeout is set only when `periphBegin` is `true` — i.e. when this library performed `wire->begin()` itself. If the caller already called `Wire.begin()` (the `periphBegin=false` path), their Wire configuration is left untouched on the assumption they're managing it explicitly.
- Cores that don't define `WIRE_HAS_TIMEOUT` (older AVR cores, some non-AVR cores) compile out the entire block — no behavioural change there.

### Tests run locally

- `python3 ci/run-clang-format.py --clang-format-executable clang-format -e 'ci/*' -e 'bin/*' Adafruit_SSD1306.cpp` → clean
- Full platform matrix deferred to CI (Arduino Library CI workflow)

### Maintainer signal

Per @ladyada's comment on #288: *"ok can you submit a simple PR that passes CI?"* — happy to iterate if anything here needs adjusting.
